### PR TITLE
!!!Improve Index read API to read from the end

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -407,6 +407,7 @@ class Index {
      * @returns {Entry|boolean} The entry at the given index position or false if out of bounds.
      */
     get(index) {
+        if (index < 0) index += this.length + 1;
         if (index < 1 || index > this.length) {
             return false;
         }
@@ -445,9 +446,9 @@ class Index {
      * @returns {Array<Entry>|boolean} An array of entries for the given range or false on error.
      */
     range(from, until) {
-        if (from < 0) from += this.length;
+        if (from < 0) from += this.length + 1;
         until = until || this.length;
-        if (until < 0) until += this.length;
+        if (until < 0) until += this.length + 1;
 
         if (!this.validRange(from, until)) {
             return false;

--- a/test/Index.spec.js
+++ b/test/Index.spec.js
@@ -91,6 +91,17 @@ describe('Index', function() {
             expect(index.get(51)).to.be(false);
         });
 
+        it('can read entry from the end', function() {
+            index = new Index('test/data/.index');
+            for (let i = 1; i <= 50; i++) {
+                index.add(new Index.Entry(i, i));
+            }
+            index.close();
+            index.open();
+            let entry = index.get(-1);
+            expect(entry.number).to.be(50);
+        });
+
         it('returns false on closed index', function() {
             index = new Index('test/data/.index');
             index.add(new Index.Entry(1, 1));
@@ -154,8 +165,9 @@ describe('Index', function() {
             index.close();
             index.open();
             let entries = index.range(-15);
+            expect(entries.length).to.be(15);
             for (let i = 0; i < entries.length; i++) {
-                expect(entries[i].number).to.be(50 - 15 + i);
+                expect(entries[i].number).to.be(36 + i);
             }
         });
 
@@ -167,7 +179,7 @@ describe('Index', function() {
             index.close();
             index.open();
             let entries = index.range(1, -15);
-            expect(entries.length).to.be(35);
+            expect(entries.length).to.be(36);   // 36 because end is inclusive
             for (let i = 0; i < entries.length; i++) {
                 expect(entries[i].number).to.be(1 + i);
             }

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -210,7 +210,7 @@ describe('Storage', function() {
             storage.open();
 
             let documents = storage.readRange(-4);
-            let i = 6;
+            let i = 7;
             for (let doc of documents) {
                 expect(doc).to.eql({ foo: i++ });
             }
@@ -227,12 +227,12 @@ describe('Storage', function() {
             storage.close();
             storage.open();
 
-            let documents = storage.readRange(1, -4);
+            let documents = storage.readRange(1, -4);   // readRange(1, 7)
             let i = 1;
             for (let doc of documents) {
                 expect(doc).to.eql({ foo: i++ });
             }
-            expect(i).to.be(7);
+            expect(i).to.be(8);
         });
 
         it('can read a range from secondary index', function() {


### PR DESCRIPTION
An index number < 0 will indicate to read from the end of the index.
Therefore, `get(-1)` is equal to `get(index.length)` or more generically
`-n` equals `index.length + 1 - n` and reads the nth item from the end.
The behaviour in `range()` has been fixed to match accordingly. Before
`range(-1)` would return the last two items, where it now returns only the
 last. Before `range(1, -1)` would return all but the last, now it is equal
 to `range(1)` and `range(1, index.length)`.

Fixes #12