### PR TITLE
Make JoinEventStream deterministically iterate events

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "mkdirp": "^0.5.1",
-    "uuid": "^3.1.0"
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "coveralls": "^2.13.1",

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -1,6 +1,5 @@
 const EventStream = require('./EventStream');
 const JoinEventStream = require('./JoinEventStream');
-const uuid = require('uuid').v4;
 const fs = require('fs');
 const path = require('path');
 const EventEmitter = require('events');
@@ -163,7 +162,7 @@ class EventStore extends EventEmitter {
             throw new OptimisticConcurrencyError(`Optimistic Concurrency error. Expected stream "${streamName}" at version ${expectedVersion} but is at version ${streamVersion}.`);
         }
 
-        const commitId = uuid();
+        const commitId = this.storage.index.length;
         let commitVersion = 0;
         const committedAt = Date.now();
         const commit = Object.assign({

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -51,7 +51,7 @@ class JoinEventStream extends EventStream {
             if (value === false) {
                 return;
             }
-            if (nextIndex === -1 || this._next[nextIndex].metadata.committedAt >= value.metadata.committedAt) {
+            if (nextIndex === -1 || this._next[nextIndex].metadata.commitId > value.metadata.commitId) {
                 nextIndex = index;
             }
         });


### PR DESCRIPTION
This is achieved by making the commitId the global event sequence number
instead of an uuid. As a side-effect, this removes the dependency on the
uuid library.