### PR TITLE
Add support for consumers starting from arbitrary positions

### DIFF
--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -286,10 +286,11 @@ class EventStore extends EventEmitter {
      *
      * @param {string} streamName The name of the stream to consume.
      * @param {string} identifier The unique identifying name of this consumer.
+     * @param {number} [since] The stream revision to start consuming from.
      * @returns {Consumer} A durable consumer for the given stream.
      */
-    getConsumer(streamName, identifier) {
-        const consumer = new Consumer(this.storage, 'stream-' + streamName, identifier);
+    getConsumer(streamName, identifier, since = 0) {
+        const consumer = new Consumer(this.storage, 'stream-' + streamName, identifier, since);
         return consumer.pipe(new EventUnwrapper());
     }
 

--- a/test/Consumer.spec.js
+++ b/test/Consumer.spec.js
@@ -83,6 +83,18 @@ describe('Consumer', function() {
         storage.write({ type: 'Foobar', id: 3 });
     });
 
+    it('can start from arbitrary position', function(done){
+        consumer = new Consumer(storage, 'foobar', 'consumer1', 2);
+        let expected = 3;
+        consumer.on('data', document => {
+            expect(document.id).to.be(expected);
+            done();
+        });
+        storage.write({ type: 'Foobar', id: 1 });
+        storage.write({ type: 'Foobar', id: 2 });
+        storage.write({ type: 'Foobar', id: 3 });
+    });
+
     it('stops when pushing fails', function(done){
         consumer = new Consumer(storage, 'foobar', 'consumer1');
         consumer.on('caught-up', () => {


### PR DESCRIPTION
Consumers may now specify a stream revision that they want to start consuming from.

Resolves #26