### PR TITLE
TASK: Remove noAssert flags from buffer read/writes

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -189,7 +189,7 @@ class Index {
         metadataSize += pad + 1;
         const metadataBuffer = Buffer.allocUnsafe(8 + 4 + metadataSize);
         metadataBuffer.write(HEADER_MAGIC, 0, 8, 'utf8');
-        metadataBuffer.writeUInt32BE(metadataSize, 8, true);
+        metadataBuffer.writeUInt32BE(metadataSize, 8);
         metadataBuffer.write(metadata, 8 + 4, metadataSize, 'utf8');
         fs.writeSync(this.fd, metadataBuffer, 0, metadataBuffer.byteLength, 0);
         this.headerSize = 8 + 4 + metadataSize;
@@ -232,7 +232,7 @@ class Index {
             }
             throw new Error('Invalid file header.');
         }
-        const metadataSize = headerBuffer.readUInt32BE(8, true);
+        const metadataSize = headerBuffer.readUInt32BE(8);
         if (metadataSize < 3) {
             throw new Error('Invalid metadata size.');
         }

--- a/src/IndexEntry.js
+++ b/src/IndexEntry.js
@@ -80,10 +80,10 @@ class Entry extends Array {
      * @return {Entry} A new entry matching the values from the Buffer.
      */
     static fromBuffer(buffer, offset = 0) {
-        const number     = buffer.readUInt32LE(offset, true);
-        const position   = buffer.readUInt32LE(offset +  4, true);
-        const size       = buffer.readUInt32LE(offset +  8, true);
-        const partition  = buffer.readUInt32LE(offset + 12, true);
+        const number     = buffer.readUInt32LE(offset);
+        const position   = buffer.readUInt32LE(offset +  4);
+        const size       = buffer.readUInt32LE(offset +  8);
+        const partition  = buffer.readUInt32LE(offset + 12);
         return new this(number, position, size, partition);
     }
 
@@ -95,10 +95,10 @@ class Entry extends Array {
      * @return {number} The size of the data written. Will always be 16.
      */
     toBuffer(buffer, offset) {
-        buffer.writeUInt32LE(this[0], offset, true);
-        buffer.writeUInt32LE(this[1], offset +  4, true);
-        buffer.writeUInt32LE(this[2], offset +  8, true);
-        buffer.writeUInt32LE(this[3], offset + 12, true);
+        buffer.writeUInt32LE(this[0], offset);
+        buffer.writeUInt32LE(this[1], offset +  4);
+        buffer.writeUInt32LE(this[2], offset +  8);
+        buffer.writeUInt32LE(this[3], offset + 12);
         return Entry.size;
     }
 

--- a/test/Index.spec.js
+++ b/test/Index.spec.js
@@ -58,7 +58,7 @@ describe('Index', function() {
     it('throws on opening an index file with wrong metadata size', function() {
         const metadataBuffer = Buffer.allocUnsafe(8 + 4);
         metadataBuffer.write("nesidx01", 0, 8, 'utf8');
-        metadataBuffer.writeUInt32BE(0, 8, true);
+        metadataBuffer.writeUInt32BE(0, 8);
         fs.writeFileSync('test/data/.index', metadataBuffer);
 
         expect(() => index = new Index('test/data/.index')).to.throwError(/Invalid metadata size/);
@@ -67,7 +67,7 @@ describe('Index', function() {
     it('throws on opening an index file with too large metadata size', function() {
         const metadataBuffer = Buffer.allocUnsafe(8 + 4 + 3);
         metadataBuffer.write("nesidx01", 0, 8, 'utf8');
-        metadataBuffer.writeUInt32BE(255, 8, true);
+        metadataBuffer.writeUInt32BE(255, 8);
         metadataBuffer.write("{}\n", 12, 3, 'utf8');
         fs.writeFileSync('test/data/.index', metadataBuffer);
 
@@ -77,7 +77,7 @@ describe('Index', function() {
     it('throws on opening an index file with invalid metadata', function() {
         const metadataBuffer = Buffer.allocUnsafe(8 + 4 + 3);
         metadataBuffer.write("nesidx01", 0, 8, 'utf8');
-        metadataBuffer.writeUInt32BE(255, 8, true);
+        metadataBuffer.writeUInt32BE(255, 8);
         metadataBuffer.write("{x$", 12, 3, 'utf8');
         fs.writeFileSync('test/data/.index', metadataBuffer);
 


### PR DESCRIPTION
This flag was removed with nodejs 10.x for good reasons.