### PR TITLE
BUGFIX: Remove writeFile left-over

### DIFF
--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -165,7 +165,6 @@ class Consumer extends stream.Readable {
             }
             ++this.position;
         }
-        fs.writeFileSync(this.fileName, this.position);
     }
 
     /**


### PR DESCRIPTION
In the case of a crash during document handling, the state of the consumer was possibly lost. Otherwise, the catch-up process was just slower than necessary, due to unneeded file IO.