### PR TITLE
Add support for getting stream version

### DIFF
--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -230,6 +230,18 @@ class EventStore extends EventEmitter {
     }
 
     /**
+     * @api
+     * @param {string} streamName The name of the stream to get the version for.
+     * @returns {number} The version that the given stream is at currently, or -1 if the stream does not exist.
+     */
+    getStreamVersion(streamName) {
+        if (!(streamName in this.streams)) {
+            return -1;
+        }
+        return this.streams[streamName].index.length;
+    }
+
+    /**
      * Get an event stream for the given stream name within the revision boundaries.
      *
      * @api

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -14,6 +14,16 @@ function adjustedRevision(rev) {
 }
 
 /**
+ * Return the lower absolute version given a version and a maxVersion constraint.
+ * @param {number} version
+ * @param {number} maxVersion
+ * @returns {number}
+ */
+function minVersion(version, maxVersion) {
+    return Math.min(version, maxVersion < 0 ? version + maxVersion + 1 : maxVersion);
+}
+
+/**
  * An event stream is a simple wrapper around an iterator over storage documents.
  * It implements a node readable stream interface.
  */
@@ -37,10 +47,12 @@ class EventStream extends stream.Readable {
         this.name = name;
         if (eventStore.streams[name]) {
             const streamIndex = eventStore.streams[name].index;
+            this.version = minVersion(streamIndex.length, maxRevision);
             minRevision = adjustedRevision(minRevision);
             maxRevision = adjustedRevision(maxRevision);
             this.iterator = eventStore.storage.readRange(minRevision, maxRevision, streamIndex);
         } else {
+            this.version = -1;
             this.iterator = { next() { return { done: true }; } };
         }
     }

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -269,6 +269,35 @@ describe('EventStore', function() {
 
     });
 
+    describe('getStreamVersion', function() {
+
+        it('returns -1 if the stream does not exist', function() {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+            expect(eventstore.getStreamVersion('foo')).to.be(-1);
+        });
+
+        it('returns 0 if the stream is empty', function() {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+            eventstore.createEventStream('foo', () => true);
+            expect(eventstore.getStreamVersion('foo')).to.be(0);
+        });
+
+        it('returns the version of the stream', function(done) {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+            eventstore.commit('foo', [{ type: 'foo' }], () => {
+                expect(eventstore.getStreamVersion('foo')).to.be(1);
+                done();
+            });
+        });
+
+    });
+
     describe('getEventStream', function() {
 
         it('can open existing streams', function(done) {

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -11,7 +11,10 @@ describe('EventStream', function() {
         mockEventStore = {
             streams: {
                 'foo': {
-                    index: 'foo-index'
+                    index: {
+                        name: 'foo-index',
+                        length: events.length
+                    }
                 }
             },
             storage: {
@@ -29,6 +32,20 @@ describe('EventStream', function() {
 
     it('makes the name available', function(){
         expect(stream.name).to.be('foo');
+    });
+
+    it('has version -1 if stream does not exist', function(){
+        stream = new EventStream('foo-bar-baz', mockEventStore);
+        expect(stream.version).to.be(-1);
+    });
+
+    it('makes the version available', function(){
+        expect(stream.version).to.be(events.length);
+    });
+
+    it('adjusts the version to given maxRevision constraint', function(){
+        stream = new EventStream('foo', mockEventStore, 0, -2);
+        expect(stream.version).to.be(events.length - 1);
     });
 
     it('throws if no name specified in constructor', function(){


### PR DESCRIPTION
This makes `EventStore.getStreamVersion(streamName)` and `EventStore.getEventStream(streamName).version` available in order to retrieve the current version of a stream. The version of the `EventStream` is the version as of the time the stream was retrieved and is constrained by the given `maxRevision` parameter.