### PR TITLE
Aligned partition with metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,11 @@ Note: If there are any misconceptions on my side to the ACID semantics, let me k
 
 Currently, the `storage` guarantees a consistent global ordering on all events by managing a global primary index. This makes
 sure that streams that are made up of multiple write-streams will stay consistent when re-reading all events. This has some
-issues though, like not being able to consistently reindex a storage, which is discussed in https://github.com/albe/node-event-storage/issues/24. Therefore, this guarantee may be relaxed in later versions.
+issues though, like not being able to consistently reindex a storage, which is discussed in https://github.com/albe/node-event-storage/issues/24.
+
+Since version 0.8 the storage also stores a monotonic clock stamp and an external sequence number together with the document.
+This way, a consistent global order can also be reconsituted without a global index. In a later version, the global index might
+therefore be removed and reindexing a storage be possible, which allows to rebuild a consistent state after a destructive crash.
 
 ### Event Streams
 

--- a/src/Clock.js
+++ b/src/Clock.js
@@ -1,0 +1,31 @@
+const TIME_BASE = process.hrtime();
+const DATE_BASE_US = Date.now() * 1000.0 + 999.0; // DATE_BASE_US should match the TIME_BASE with lower resolution, but never be less
+const US_PER_SEC = 1.0e6;
+const CLOCK_ACCURACY_US = 1; // two process.hrtime() calls take roughly this long, so this is the accuracy we can measure time
+
+/**
+ * A simple clock that measures monotonic time elapsed since a specific epoch in microseconds.
+ * Hence, in theory, this clock supports providing a unique sequential numbering for up to 1 million events/s,
+ * which is far beyond typical write capabilities of SSD drives in single thread scenarios.
+ */
+class Clock {
+
+    /**
+     * @param {Date|number} epoch The epoch to base this clock on, either as a Date or a number of the amount of milliseconds since the unix epoch
+     */
+    constructor(epoch) {
+        this.epoch = Math.floor((epoch instanceof Date ? epoch.getTime() : Number(epoch)) * 1000.0);
+    }
+
+    /**
+     * @return {number} The number of microseconds since the epoch given in the constructor. The decimal part denotes the accuracy of the clock in milliseconds.
+     * @note Needs to allow at least tens of ms accuracy, better hundreds of ms
+     */
+    time() {
+        const delta = process.hrtime(TIME_BASE);
+        return DATE_BASE_US - this.epoch + (delta[0] * US_PER_SEC + Math.floor(delta[1] / 1000)) + (CLOCK_ACCURACY_US / 1000.0);
+    }
+
+}
+
+module.exports = Clock;

--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -2,8 +2,9 @@ const stream = require('stream');
 const fs = require('fs');
 const path = require('path');
 const mkdirpSync = require('mkdirp').sync;
+const { assert } = require('./util');
 
-const Storage = require('./Storage');
+const Storage = require('./Storage/ReadableStorage');
 const MAX_CATCHUP_BATCH = 10;
 
 /**
@@ -20,15 +21,9 @@ class Consumer extends stream.Readable {
     constructor(storage, indexName, identifier, startFrom = 0) {
         super({ objectMode: true });
 
-        if (!(storage instanceof Storage)) {
-            throw new Error('Must provide a storage for the consumer.');
-        }
-        if (!indexName) {
-            throw new Error('Must specify an index name for the consumer.');
-        }
-        if (!identifier) {
-            throw new Error('Must specify an identifier name for the consumer.');
-        }
+        assert(storage instanceof Storage, 'Must provide a storage for the consumer.');
+        assert(typeof indexName === 'string' && indexName !== '', 'Must specify an index name for the consumer.');
+        assert(typeof identifier === 'string' && identifier !== '', 'Must specify an identifier name for the consumer.');
 
         this.initializeStorage(storage, indexName, identifier);
         this.restoreState(startFrom);
@@ -83,9 +78,8 @@ class Consumer extends stream.Readable {
      * @api
      */
     setState(newState) {
-        if (!this.handleDocument) {
-            throw new Error('Called setState outside of document handler!');
-        }
+        assert(this.handleDocument, 'Called setState outside of document handler!');
+
         this.state = Object.freeze(newState);
     }
 

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -1,4 +1,5 @@
 const stream = require('stream');
+const { assert } = require('./util');
 
 /**
  * Adjusts a revision number from the EventStore/EventStream interface range into the underlying storage item number.
@@ -37,12 +38,8 @@ class EventStream extends stream.Readable {
      */
     constructor(name, eventStore, minRevision = 0, maxRevision = -1) {
         super({ objectMode: true });
-        if (typeof name !== 'string' || !name) {
-            throw new Error('Need to specify a stream name.');
-        }
-        if (!eventStore) {
-            throw new Error(`Need to provide EventStore instance to create EventStream ${name}.`);
-        }
+        assert(typeof name === 'string' && name !== '', 'Need to specify a stream name.');
+        assert( typeof eventStore === 'object' && eventStore !== null, `Need to provide EventStore instance to create EventStream ${name}.`);
 
         this.name = name;
         if (eventStore.streams[name]) {

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -39,7 +39,7 @@ class EventStream extends stream.Readable {
     constructor(name, eventStore, minRevision = 0, maxRevision = -1) {
         super({ objectMode: true });
         assert(typeof name === 'string' && name !== '', 'Need to specify a stream name.');
-        assert( typeof eventStore === 'object' && eventStore !== null, `Need to provide EventStore instance to create EventStream ${name}.`);
+        assert(typeof eventStore === 'object' && eventStore !== null, `Need to provide EventStore instance to create EventStream ${name}.`);
 
         this.name = name;
         if (eventStore.streams[name]) {

--- a/src/Index/ReadableIndex.js
+++ b/src/Index/ReadableIndex.js
@@ -392,3 +392,4 @@ class ReadableIndex extends EventEmitter {
 
 module.exports = ReadableIndex;
 module.exports.Entry = Entry;
+module.exports.HEADER_MAGIC = HEADER_MAGIC;

--- a/src/Index/WritableIndex.js
+++ b/src/Index/WritableIndex.js
@@ -179,8 +179,8 @@ class WritableIndex extends ReadableIndex {
      * @returns {number} The index position for the entry. It matches the index size after the insertion.
      */
     add(entry, callback) {
-        assertEqual(entry.constructor.name, this.EntryClass.name, `Wrong entry object. Expected "${this.EntryClass.name}" but got "${entry.constructor.name}".`);
-        assertEqual(entry.constructor.size, this.EntryClass.size, `Invalid entry size. Expected ${this.EntryClass.size} but got ${entry.constructor.size}.`);
+        assertEqual(entry.constructor.name, this.EntryClass.name, `Wrong entry object.`);
+        assertEqual(entry.constructor.size, this.EntryClass.size, `Invalid entry size.`);
 
         if (this.readUntil === this.data.length - 1) {
             this.readUntil++;

--- a/src/Index/WritableIndex.js
+++ b/src/Index/WritableIndex.js
@@ -50,10 +50,10 @@ class WritableIndex extends ReadableIndex {
         }
 
         this.fileMode = 'a+';
-        this.writeBuffer = Buffer.allocUnsafe(options.writeBufferSize >>> 0);
+        this.writeBuffer = Buffer.allocUnsafe(options.writeBufferSize >>> 0); // jshint ignore:line
         this.writeBufferCursor = 0;
         this.flushCallbacks = [];
-        this.flushDelay = options.flushDelay >>> 0;
+        this.flushDelay = options.flushDelay >>> 0; // jshint ignore:line
         this.syncOnFlush = !!options.syncOnFlush;
     }
 

--- a/src/Index/WritableIndex.js
+++ b/src/Index/WritableIndex.js
@@ -1,10 +1,7 @@
 const fs = require('fs');
 const mkdirpSync = require('mkdirp').sync;
 const ReadableIndex = require('./ReadableIndex');
-const { assertEqual } = require('../util');
-
-// node-event-store-index V01
-const HEADER_MAGIC = "nesidx01";
+const { assertEqual, buildMetadataHeader } = require('../util');
 
 /**
  * An index is a simple append-only file that stores an ordered list of entry elements pointing to the actual file position
@@ -105,17 +102,9 @@ class WritableIndex extends ReadableIndex {
         if (!this.metadata) {
             this.metadata = {entryClass: this.EntryClass.name, entrySize: this.EntryClass.size};
         }
-        let metadata = JSON.stringify(this.metadata);
-        let metadataSize = Buffer.byteLength(metadata, 'utf8');
-        const pad = (16 - ((8 + 4 + metadataSize + 1) % 16)) % 16;
-        metadata += ' '.repeat(pad) + "\n";
-        metadataSize += pad + 1;
-        const metadataBuffer = Buffer.allocUnsafe(8 + 4 + metadataSize);
-        metadataBuffer.write(HEADER_MAGIC, 0, 8, 'utf8');
-        metadataBuffer.writeUInt32BE(metadataSize, 8);
-        metadataBuffer.write(metadata, 8 + 4, metadataSize, 'utf8');
+        const metadataBuffer = buildMetadataHeader(ReadableIndex.HEADER_MAGIC, this.metadata);
         fs.writeSync(this.fd, metadataBuffer, 0, metadataBuffer.byteLength, 0);
-        this.headerSize = 8 + 4 + metadataSize;
+        this.headerSize = metadataBuffer.byteLength;
     }
 
     /**

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const EventEmitter = require('events');
 
-const DEFAULT_READ_BUFFER_SIZE = 4 * 1024;
+const DEFAULT_READ_BUFFER_SIZE = 64 * 1024;
 const DOCUMENT_HEADER_SIZE = 16;
 const DOCUMENT_ALIGNMENT = 4;
 

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -213,7 +213,7 @@ class ReadablePartition extends EventEmitter {
      */
     readDataLength(buffer, offset, position, size) {
         const dataLength = buffer.readUInt32BE(offset);
-        assert(dataLength > 0 && dataLength <= 0x3ffffff, `Error reading document size from ${position}, got ${dataLength}.`);
+        assert(dataLength > 0 && dataLength <= 64 * 1024 * 1024, `Error reading document size from ${position}, got ${dataLength}.`);
 
         if (size && dataLength !== size) {
             throw new InvalidDataSizeError(`Invalid document size ${dataLength} at position ${position}, expected ${size}.`);

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -265,6 +265,8 @@ class ReadablePartition extends EventEmitter {
             return false;
         }
 
+        assert((position % DOCUMENT_ALIGNMENT) === 0, `Invalid read position. Needs to be a multiple of ${DOCUMENT_ALIGNMENT}.`);
+
         const reader = this.prepareReadBuffer(position);
         if (reader.length < size + DOCUMENT_HEADER_SIZE) {
             return false;

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const mkdirpSync = require('mkdirp').sync;
 const ReadablePartition = require('./ReadablePartition');
-const { buildMetadataHeader } = require('../util');
+const { assert, buildMetadataHeader } = require('../util');
 
 const DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
 const DOCUMENT_HEADER_SIZE = 16;
@@ -186,6 +186,8 @@ class WritablePartition extends ReadablePartition {
             return false;
         }
         const dataSize = Buffer.byteLength(data, 'utf8');
+        assert(dataSize <= 0x3ffffff, 'Document is too large! Maximum is 64 MB');
+
         const dataPad = padData(dataSize);
         const padSize = Buffer.byteLength(dataPad, 'utf8');
         const writeSize = dataSize + padSize;

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -215,7 +215,8 @@ class WritablePartition extends ReadablePartition {
         const dataHeader = Buffer.alloc(DOCUMENT_HEADER_SIZE);
         this.writeDocumentHeader(dataHeader, 0, dataSize, sequenceNumber);
 
-        let bytesWritten = fs.writeSync(this.fd, dataHeader);
+        let bytesWritten = 0;
+        bytesWritten += fs.writeSync(this.fd, dataHeader);
         bytesWritten += fs.writeSync(this.fd, data);
         if (typeof callback === 'function') {
             process.nextTick(callback);

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -166,6 +166,13 @@ class WritablePartition extends ReadablePartition {
         }
     }
 
+    /**
+     * @private
+     * @param {Buffer} buffer The buffer to write the document header to
+     * @param {number} offset The offset inside the buffer to start writing at
+     * @param {number} dataSize The size of the document
+     * @returns {number} The size of the document header
+     */
     writeDocumentHeader(buffer, offset, dataSize) {
         buffer.writeUInt32BE(dataSize, offset);
         // TODO: Write other document metadata

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -186,7 +186,7 @@ class WritablePartition extends ReadablePartition {
             return false;
         }
         const dataSize = Buffer.byteLength(data, 'utf8');
-        assert(dataSize <= 0x3ffffff, 'Document is too large! Maximum is 64 MB');
+        assert(dataSize <= 64 * 1024 * 1024, 'Document is too large! Maximum is 64 MB');
 
         const dataPad = padData(dataSize);
         const padSize = Buffer.byteLength(dataPad, 'utf8');

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -25,6 +25,7 @@ class ReadableStorage extends EventEmitter {
      * @param {number} [config.readBufferSize] Size of the read buffer in bytes. Default 4096.
      * @param {Object} [config.indexOptions] An options object that should be passed to all indexes on construction.
      * @param {string} [config.hmacSecret] A private key that is used to verify matchers retrieved from indexes.
+     * @param {Object} [config.metadata] A metadata object to be stored in all partitions belonging to this storage.
      */
     constructor(storageName = 'storage', config = {}) {
         super();
@@ -39,7 +40,8 @@ class ReadableStorage extends EventEmitter {
             dataDirectory: '.',
             indexFile: this.storageFile + '.index',
             indexOptions: {},
-            hmacSecret: ''
+            hmacSecret: '',
+            metadata: {}
         };
         config = Object.assign(defaults, config);
         this.serializer = config.serializer;

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -3,7 +3,7 @@ const path = require('path');
 const EventEmitter = require('events');
 const Partition = require('../Partition');
 const Index = require('../Index');
-const { createHmac, matches, buildMetadataForMatcher } = require('../util');
+const { assert, createHmac, matches, buildMetadataForMatcher } = require('../util');
 
 const DEFAULT_READ_BUFFER_SIZE = 4 * 1024;
 
@@ -170,10 +170,7 @@ class ReadableStorage extends EventEmitter {
      * @throws {Error} If an id is given and no such partition exists.
      */
     getPartition(partitionIdentifier) {
-        /* istanbul ignore next  */
-        if (!this.partitions[partitionIdentifier]) {
-            throw new Error(`Partition #${partitionIdentifier} does not exist.`);
-        }
+        assert(partitionIdentifier in this.partitions, `Partition #${partitionIdentifier} does not exist.`);
 
         this.partitions[partitionIdentifier].open();
         return this.partitions[partitionIdentifier];
@@ -234,9 +231,8 @@ class ReadableStorage extends EventEmitter {
         }
 
         const entries = index.range(from, until);
-        if (entries === false) {
-            throw new Error(`Range scan error for range ${from} - ${until}.`);
-        }
+        assert(entries !== false, `Range scan error for range ${from} - ${until}.`);
+
         for (let entry of entries) {
             const document = this.readFrom(entry.partition, entry.position, entry.size);
             yield document;
@@ -259,9 +255,8 @@ class ReadableStorage extends EventEmitter {
         }
 
         const indexName = this.storageFile + '.' + name + '.index';
-        if (!fs.existsSync(path.join(this.indexDirectory, indexName))) {
-            throw new Error(`Index "${name}" does not exist.`);
-        }
+        assert(fs.existsSync(path.join(this.indexDirectory, indexName)), `Index "${name}" does not exist.`);
+
         const metadata = buildMetadataForMatcher(matcher, this.hmac);
         let { index } = this.secondaryIndexes[name] = this.createIndex(indexName, Object.assign({}, this.indexOptions, { metadata }));
 

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -180,7 +180,7 @@ class WritableStorage extends ReadableStorage {
 
         const partitionName = this.partitioner(document, this.index.length + 1);
         const partition = this.getPartition(partitionName);
-        const position = partition.write(data, callback);
+        const position = partition.write(data, this.length, callback);
 
         assert(position !== false, 'Error writing document.');
 

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -4,9 +4,11 @@ const path = require('path');
 const WritablePartition = require('../Partition/WritablePartition');
 const WritableIndex = require('../Index/WritableIndex');
 const ReadableStorage = require('./ReadableStorage');
-const { matches, buildMetadataForMatcher, buildMatcherFromMetadata } = require('../util');
+const { assert, matches, buildMetadataForMatcher, buildMatcherFromMetadata } = require('../util');
 
 const DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
+
+class StorageLockedError extends Error {}
 
 /**
  * An append-only storage with highly performant positional range scans.
@@ -85,7 +87,7 @@ class WritableStorage extends ReadableStorage {
             if (e.code !== 'EEXIST') {
                 throw new Error(`Error creating lock for storage ${this.storageFile}: ` + e.message);
             }
-            throw new Error(`Storage ${this.storageFile} is locked by another process`);
+            throw new StorageLockedError(`Storage ${this.storageFile} is locked by another process`);
         }
         return true;
     }
@@ -180,10 +182,8 @@ class WritableStorage extends ReadableStorage {
         const partition = this.getPartition(partitionName);
         const position = partition.write(data, callback);
 
-        /* istanbul ignore next  */
-        if (position === false) {
-            throw new Error('Error writing document.');
-        }
+        assert(position !== false, 'Error writing document.');
+
         const indexEntry = this.addIndex(partition.id, position, dataSize, document);
         this.forEachSecondaryIndex((index, name) => {
             if (!index.isOpen()) {
@@ -216,9 +216,7 @@ class WritableStorage extends ReadableStorage {
             return this.openIndex(name, matcher);
         }
 
-        if (!matcher) {
-            throw new Error('Need to specify a matcher.');
-        }
+        assert((typeof matcher === 'object' || typeof matcher === 'function') && matcher !== null, 'Need to specify a matcher.');
 
         const metadata = buildMetadataForMatcher(matcher, this.hmac);
         const { index } = this.createIndex(indexName, Object.assign({}, this.indexOptions, { metadata }));
@@ -365,3 +363,4 @@ class WritableStorage extends ReadableStorage {
 }
 
 module.exports = WritableStorage;
+module.exports.StorageLockedError = StorageLockedError;

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const EventEmitter = require('events');
+const { assert } = require('./util');
 
 const directoryWatchers = {};
 
@@ -17,10 +18,8 @@ class DirectoryWatcher extends EventEmitter {
      */
     constructor(directory, options = {}) {
         directory = path.normalize(directory);
-        /* istanbul ignore if */
-        if (!fs.existsSync(directory)) {
-            throw new Error('Can not watch a non-existing directory.');
-        }
+        assert(fs.existsSync(directory), 'Can not watch a non-existing directory.');
+
         if (directoryWatchers[directory]) {
             directoryWatchers[directory].references++;
             return directoryWatchers[directory];
@@ -87,9 +86,8 @@ class Watcher {
      * @api
      */
     on(eventType, handler) {
-        if (!this.handlers[eventType]) {
-            throw new Error(`Event type ${eventType} is unknown. Only 'change' and 'rename' are supported.`);
-        }
+        assert(eventType in this.handlers, `Event type ${eventType} is unknown. Only 'change' and 'rename' are supported.`);
+
         this.handlers[eventType].push(handler);
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,19 @@
 const crypto = require('crypto');
 
 /**
+ * Assert that actual and expected match or throw an Error with the given message.
+ *
+ * @param {*} actual
+ * @param {*} expected
+ * @param {string} message
+ */
+function assertEqual(actual, expected, message) {
+    if (actual !== expected) {
+        throw new Error(message + `, got ${actual}, expected ${expected}.`);
+    }
+}
+
+/**
  * @param {string} secret The secret to use for calculating further HMACs
  * @returns {function(string)} A function that calculates the HMAC for a given string
  */
@@ -68,6 +81,28 @@ function buildMatcherFromMetadata(matcherMetadata, hmac) {
 }
 
 /**
+ * Build a buffer containing the file magic header and a JSON stringified metadata block, padded to be a multiple of 16 bytes long.
+ *
+ * @param {string} magic
+ * @param {object} metadata
+ * @returns {Buffer} A buffer containing the header data
+ */
+function buildMetadataHeader(magic, metadata) {
+    assertEqual(magic.length, 8, 'The header magic bytes length is wrong');
+    let metadataString = JSON.stringify(metadata);
+    let metadataSize = Buffer.byteLength(metadataString, 'utf8');
+    // 8 byte MAGIC, 4 byte metadata size, 1 byte line break
+    const pad = (16 - ((8 + 4 + metadataSize + 1) % 16)) % 16;
+    metadataString += ' '.repeat(pad) + "\n";
+    metadataSize += pad + 1;
+    const metadataBuffer = Buffer.allocUnsafe(8 + 4 + metadataSize);
+    metadataBuffer.write(magic, 0, 8, 'utf8');
+    metadataBuffer.writeUInt32BE(metadataSize, 8);
+    metadataBuffer.write(metadataString, 8 + 4, metadataSize, 'utf8');
+    return metadataBuffer;
+}
+
+/**
  * Do a binary search for number in the range 1-length with values retrieved via a provided getter.
  *
  * @param {number} number The value to search for
@@ -102,19 +137,6 @@ function binarySearch(number, length, get) {
 }
 
 /**
- * Assert that actual and expected match or throw an Error with the given message.
- *
- * @param {*} actual
- * @param {*} expected
- * @param {string} message
- */
-function assertEqual(actual, expected, message) {
-    if (actual !== expected) {
-        throw new Error(message + `, got ${actual}, expected ${expected}.`);
-    }
-}
-
-/**
  * @param {number} index The 1-based index position to wrap around if < 0 and check against the bounds.
  * @param {number} length The length of the index and upper bound.
  * @returns {number|boolean} The wrapped index or false if index out of bounds.
@@ -133,4 +155,13 @@ function wrapAndCheck(index, length) {
     return index;
 }
 
-module.exports = { assertEqual, wrapAndCheck, binarySearch, createHmac, matches, buildMetadataForMatcher, buildMatcherFromMetadata };
+module.exports = {
+    assertEqual,
+    wrapAndCheck,
+    binarySearch,
+    createHmac,
+    matches,
+    buildMetadataForMatcher,
+    buildMatcherFromMetadata,
+    buildMetadataHeader
+};

--- a/src/util.js
+++ b/src/util.js
@@ -18,11 +18,11 @@ function assertEqual(actual, expected, message) {
  *
  * @param {boolean} condition
  * @param {string} message
- * @param {typeof Error} errorType
+ * @param {typeof Error} ErrorType
  */
-function assert(condition, message, errorType = Error) {
+function assert(condition, message, ErrorType = Error) {
     if (!condition) {
-        throw new errorType(message);
+        throw new ErrorType(message);
     }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 
 /**
- * Assert that actual and expected match or throw an Error with the given message.
+ * Assert that actual and expected match or throw an Error with the given message appended by information about expected and actual value.
  *
  * @param {*} actual
  * @param {*} expected
@@ -9,7 +9,20 @@ const crypto = require('crypto');
  */
 function assertEqual(actual, expected, message) {
     if (actual !== expected) {
-        throw new Error(message + `, got ${actual}, expected ${expected}.`);
+        throw new Error(message + (message ? ' ' : '') + `Expected "${expected}" but got "${actual}".`);
+    }
+}
+
+/**
+ * Assert that the condition holds and if not, throw an error with the given message.
+ *
+ * @param {boolean} condition
+ * @param {string} message
+ * @param {typeof Error} errorType
+ */
+function assert(condition, message, errorType = Error) {
+    if (!condition) {
+        throw new errorType(message);
     }
 }
 
@@ -88,7 +101,7 @@ function buildMatcherFromMetadata(matcherMetadata, hmac) {
  * @returns {Buffer} A buffer containing the header data
  */
 function buildMetadataHeader(magic, metadata) {
-    assertEqual(magic.length, 8, 'The header magic bytes length is wrong');
+    assertEqual(magic.length, 8, 'The header magic bytes length is wrong.');
     let metadataString = JSON.stringify(metadata);
     let metadataSize = Buffer.byteLength(metadataString, 'utf8');
     // 8 byte MAGIC, 4 byte metadata size, 1 byte line break
@@ -156,6 +169,7 @@ function wrapAndCheck(index, length) {
 }
 
 module.exports = {
+    assert,
     assertEqual,
     wrapAndCheck,
     binarySearch,

--- a/test/Partition.spec.js
+++ b/test/Partition.spec.js
@@ -213,12 +213,11 @@ describe('Partition', function() {
 
         it('throws when an unfinished write is found', function() {
             partition.open();
-            partition.write('foobar');
+            const position = partition.write('foobar');
             partition.close();
 
             let fd = fs.openSync('test/data/.part', 'r+');
-            let stat = fs.fstatSync(fd);
-            fs.ftruncateSync(fd, stat.size - 3);
+            fs.ftruncateSync(fd, partition.headerSize + position + partition.documentWriteSize('foobar'.length) - 4);
             fs.closeSync(fd);
 
             partition.open();
@@ -237,7 +236,7 @@ describe('Partition', function() {
             let pos = 0;
             for (let i = 0; i < 1000; i++) {
                 expect(partition.readFrom(pos)).to.be('foobar');
-                pos += 'foobar'.length + 11;
+                pos += partition.documentWriteSize('foobar'.length);
             }
         });
 

--- a/test/Partition.spec.js
+++ b/test/Partition.spec.js
@@ -35,7 +35,7 @@ describe('Partition', function() {
     function fillPartition(num, documentBuilder) {
         let lastPosition;
         for (let i = 1; i <= num; i++) {
-            lastPosition = partition.write(documentBuilder && documentBuilder(i) || 'foobar');
+            lastPosition = partition.write(documentBuilder && documentBuilder(i) || 'foobar', i);
         }
         partition.flush();
         return lastPosition;

--- a/test/Partition.spec.js
+++ b/test/Partition.spec.js
@@ -199,7 +199,7 @@ describe('Partition', function() {
             partition.close();
             partition.open();
 
-            expect(() => console.log(partition.readFrom(4))).to.throwError();
+            expect(() => console.log(partition.readFrom(3))).to.throwError();
         });
 
         it('throws when reading unexpected document size', function() {

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -712,7 +712,7 @@ describe('Storage', function() {
             expect(() => {
                 storage = createStorage();
                 storage.open();
-            }).to.throwError(/is locked/);
+            }).to.throwError(e => e instanceof Storage.StorageLockedError);
             storage2.close();
         });
 

--- a/test/Watcher.spec.js
+++ b/test/Watcher.spec.js
@@ -32,6 +32,12 @@ describe('Watcher', function() {
         expect(() => createWatcher('foo/')).to.throwError();
     });
 
+    it('is singleton per directory', function(){
+        const watcher1 = createWatcher('');
+        const watcher2 = createWatcher('');
+        expect(watcher1.watcher).to.equal(watcher2.watcher);
+    });
+
     it('can be closed multiple times safely', function(){
         const watcher = createWatcher('');
         watcher.close();


### PR DESCRIPTION
This adds the possiblity to add per partition metadata, uses a binary document header and aligns partition documents on 4 byte boundaries. It also stores a monotonic clock timestamp relative to the partition epoch and an optional external sequence number in the document header. This will allow to keep reads across partitions consistent even without the global index and allow to reindex documents.

Resolves #33 
Resolves #71 