### PR TITLE
Phase out nodejs 11 and test with nodejs 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "11"
   - "12"
   - "13"
+  - "14"
 
 install:
   - npm install


### PR DESCRIPTION
This removes nodejs 11 from the test matrix, which is EOL and instead adds nodejs 14.