### PR TITLE
Streamline typehint casing

### DIFF
--- a/src/Clock.js
+++ b/src/Clock.js
@@ -18,7 +18,7 @@ class Clock {
     }
 
     /**
-     * @return {number} The number of microseconds since the epoch given in the constructor. The decimal part denotes the accuracy of the clock in milliseconds.
+     * @returns {number} The number of microseconds since the epoch given in the constructor. The decimal part denotes the accuracy of the clock in milliseconds.
      * @note Needs to allow at least tens of ms accuracy, better hundreds of ms
      */
     time() {

--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -74,7 +74,7 @@ class Consumer extends stream.Readable {
      * Update the state of this consumer transactionally with the position.
      * May only be called from within the document handling callback.
      *
-     * @param {Object} newState
+     * @param {object} newState
      * @api
      */
     setState(newState) {
@@ -89,7 +89,7 @@ class Consumer extends stream.Readable {
      * @private
      * @param {string} name The name of the index the document was added for.
      * @param {number} position The 1-based position inside the index that the document was added to.
-     * @param {Object} document The document that was added.
+     * @param {object} document The document that was added.
      */
     handleNewDocument(name, position, document) {
         if (name !== this.indexName) {
@@ -134,7 +134,7 @@ class Consumer extends stream.Readable {
      * Check if this consumer has caught up. If so, register a handler for the stream and emit a 'caught-up' event.
      *
      * @private
-     * @return {boolean} True if this consumer has caught up and can
+     * @returns {boolean} True if this consumer has caught up and can
      */
     checkCaughtUp() {
         if (this.index.length <= this.position) {

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -42,10 +42,10 @@ class EventStore extends EventEmitter {
 
     /**
      * @param {string} [storeName] The name of the store which will be used as storage prefix. Default 'eventstore'.
-     * @param {Object} [config] An object with config options.
+     * @param {object} [config] An object with config options.
      * @param {string} [config.storageDirectory] The directory where the data should be stored. Default './data'.
      * @param {string} [config.streamsDirectory] The directory where the streams should be stored. Default '{storageDirectory}/streams'.
-     * @param {Object} [config.storageConfig] Additional config options given to the storage backend. See `Storage`.
+     * @param {object} [config.storageConfig] Additional config options given to the storage backend. See `Storage`.
      * @param {boolean} [config.readOnly] If the storage should be mounted in read-only mode.
      */
     constructor(storeName = 'eventstore', config = {}) {
@@ -81,7 +81,7 @@ class EventStore extends EventEmitter {
 
     /**
      * @param {string} name
-     * @param {Object} config
+     * @param {object} config
      * @returns {ReadableStorage|WritableStorage}
      */
     createStorage(name, config) {
@@ -147,11 +147,11 @@ class EventStore extends EventEmitter {
      *  - callback
      *
      * @private
-     * @param {Array<Object>|Object} events
+     * @param {Array<object>|object} events
      * @param {number} [expectedVersion]
-     * @param {Object} [metadata]
-     * @param {Function} [callback]
-     * @returns {{events: Array<Object>, metadata: object, callback: Function, expectedVersion: number}}
+     * @param {object} [metadata]
+     * @param {function} [callback]
+     * @returns {{events: Array<object>, metadata: object, callback: function, expectedVersion: number}}
      */
     static fixArgumentTypes(events, expectedVersion, metadata, callback) {
         if (!(events instanceof Array)) {
@@ -179,10 +179,10 @@ class EventStore extends EventEmitter {
      *
      * @api
      * @param {string} streamName The name of the stream to commit the events to.
-     * @param {Array<Object>|Object} events The events to commit or a single event.
+     * @param {Array<object>|object} events The events to commit or a single event.
      * @param {number} [expectedVersion] One of ExpectedVersion constants or a positive version number that the stream is supposed to be at before commit.
-     * @param {Object} [metadata] The commit metadata to use as base. Useful for replication and adding storage metadata.
-     * @param {Function} [callback] A function that will be executed when all events have been committed.
+     * @param {object} [metadata] The commit metadata to use as base. Useful for replication and adding storage metadata.
+     * @param {function} [callback] A function that will be executed when all events have been committed.
      * @throws {OptimisticConcurrencyError} if the stream is not at the expected version.
      */
     commit(streamName, events, expectedVersion = ExpectedVersion.Any, metadata = {}, callback = null) {
@@ -273,7 +273,7 @@ class EventStore extends EventEmitter {
      * @param {Array<string>} streamNames An array of the stream names to join.
      * @param {number} [minRevision] The minimum revision to include in the events (inclusive).
      * @param {number} [maxRevision] The maximum revision to include in the events (inclusive).
-     * @return {EventStream} The joined event stream.
+     * @returns {EventStream} The joined event stream.
      * @throws {Error} if any of the streams doesn't exist.
      */
     fromStreams(streamName, streamNames, minRevision = 0, maxRevision = -1) {
@@ -290,7 +290,7 @@ class EventStore extends EventEmitter {
      *
      * @api
      * @param {string} streamName The name of the stream to create.
-     * @param {Object|function(event)} matcher A matcher object, denoting the properties that need to match on an event a function that takes the event and returns true if the event should be added.
+     * @param {object|function(event)} matcher A matcher object, denoting the properties that need to match on an event a function that takes the event and returns true if the event should be added.
      * @returns {EventStream} The EventStream with all existing events matching the matcher.
      * @throws {Error} If a stream with that name already exists.
      * @throws {Error} If the stream could not be created.
@@ -346,7 +346,7 @@ class EventStore extends EventEmitter {
      * Get all commits that happened since the given store revision.
      *
      * @param {number} [since] The event revision since when to return commits (inclusive). If since is within a commit, the full commit will be returned.
-     * @returns {Generator<Object>} A generator of commit objects, each containing the commit metadata and the array of events.
+     * @returns {Generator<object>} A generator of commit objects, each containing the commit metadata and the array of events.
      */
     *getCommits(since = 0) {
         let commit;

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -57,7 +57,7 @@ class EventStream extends stream.Readable {
     /**
      * Will iterate over all events in this stream and return an array of the events.
      *
-     * @returns {Array<Object>}
+     * @returns {Array<object>}
      */
     get events() {
         if (this._events instanceof Array) {
@@ -75,7 +75,7 @@ class EventStream extends stream.Readable {
      * Iterate over the events in this stream with a callback.
      * This method is useful to gain access to the event metadata.
      *
-     * @param {function(Object, Object, string)} callback A callback function that will receive the event, the storage metadata and the original stream name for every event in this stream.
+     * @param {function(object, Object, string)} callback A callback function that will receive the event, the storage metadata and the original stream name for every event in this stream.
      */
     forEach(callback) {
         let next;
@@ -95,7 +95,7 @@ class EventStream extends stream.Readable {
     }
 
     /**
-     * @returns {Object|boolean} The next event or false if no more events in the stream.
+     * @returns {object|boolean} The next event or false if no more events in the stream.
      */
     next() {
         let next;

--- a/src/Index/ReadableIndex.js
+++ b/src/Index/ReadableIndex.js
@@ -22,12 +22,12 @@ class ReadableIndex extends EventEmitter {
 
     /**
      * @param {string} [name] The name of the file to use for storing the index.
-     * @param {Object} [options] An object with additional index options.
+     * @param {object} [options] An object with additional index options.
      * @param {typeof EntryInterface} [options.EntryClass] The entry class to use for index items. Must implement the EntryInterface methods.
      * @param {string} [options.dataDirectory] The directory to store the index file in. Default '.'.
      * @param {number} [options.writeBufferSize] The number of bytes to use for the write buffer. Default 4096.
      * @param {number} [options.flushDelay] How many ms to delay the write buffer flush to optimize throughput. Default 100.
-     * @param {Object} [options.metadata] An object containing the metadata information for this index. Will be written on initial creation and checked on subsequent openings.
+     * @param {object} [options.metadata] An object containing the metadata information for this index. Will be written on initial creation and checked on subsequent openings.
      */
     constructor(name = '.index', options = {}) {
         super();
@@ -49,7 +49,7 @@ class ReadableIndex extends EventEmitter {
 
     /**
      * @protected
-     * @param {Object} options
+     * @param {object} options
      */
     initialize(options) {
         this.data = [];

--- a/src/Index/WritableIndex.js
+++ b/src/Index/WritableIndex.js
@@ -18,12 +18,12 @@ class WritableIndex extends ReadableIndex {
 
     /**
      * @param {string} [name] The name of the file to use for storing the index.
-     * @param {Object} [options] An object with additional index options.
+     * @param {object} [options] An object with additional index options.
      * @param {EntryInterface} [options.EntryClass] The entry class to use for index items. Must implement the EntryInterface methods.
      * @param {string} [options.dataDirectory] The directory to store the index file in. Default '.'.
      * @param {number} [options.writeBufferSize] The number of bytes to use for the write buffer. Default 4096.
      * @param {number} [options.flushDelay] How many ms to delay the write buffer flush to optimize throughput. Default 100.
-     * @param {Object} [options.metadata] An object containing the metadata information for this index. Will be written on initial creation and checked on subsequent openings.
+     * @param {object} [options.metadata] An object containing the metadata information for this index. Will be written on initial creation and checked on subsequent openings.
      */
     constructor(name = '.index', options = {}) {
         if (typeof name !== 'string') {
@@ -41,7 +41,7 @@ class WritableIndex extends ReadableIndex {
 
     /**
      * @protected
-     * @param {Object} options
+     * @param {object} options
      */
     initialize(options) {
         super.initialize(options);

--- a/src/IndexEntry.js
+++ b/src/IndexEntry.js
@@ -5,7 +5,7 @@
  */
 class EntryInterface {
     /**
-     * @return {Number} The byte size of this Entry.
+     * @returns {number} The byte size of this Entry.
      */
     static get size() {}
 
@@ -13,8 +13,8 @@ class EntryInterface {
      * Read a new Entry from a Buffer object at the given offset.
      *
      * @param {Buffer} buffer The buffer object to read the index data from. 
-     * @param {Number} [offset] The buffer offset to start reading from. Default 0.
-     * @return {EntryInterface} A new entry matching the values from the Buffer.
+     * @param {number} [offset] The buffer offset to start reading from. Default 0.
+     * @returns {EntryInterface} A new entry matching the values from the Buffer.
      */
     static fromBuffer(buffer, offset = 0) {}
 
@@ -22,8 +22,8 @@ class EntryInterface {
      * Write this Entry into a Buffer object at the given offset.
      *
      * @param {Buffer} buffer The buffer object to write the index entry data to.
-     * @param {Number} offset The offset to start writing into the buffer.
-     * @return {Number} The size of the data written.
+     * @param {number} offset The offset to start writing into the buffer.
+     * @returns {number} The size of the data written.
      */
     toBuffer(buffer, offset) {}
 }
@@ -48,15 +48,15 @@ function assertValidEntryClass(EntryClass) {
 
 /**
  * Default Entry item contains information about the sequence number, the file position, the document size and the partition number.
- * @type Array<Number>
+ * @type Array<number>
  */
 class Entry extends Array {
 
     /**
-     * @param {Number} number The sequence number of the index entry.
-     * @param {Number} position The file position where the indexed document is stored.
-     * @param {Number} [size] The size of the stored document (for verification). Default 0.
-     * @param {Number} [partition] The partition where the indexed document is stored. Default 0.
+     * @param {number} number The sequence number of the index entry.
+     * @param {number} position The file position where the indexed document is stored.
+     * @param {number} [size] The size of the stored document (for verification). Default 0.
+     * @param {number} [partition] The partition where the indexed document is stored. Default 0.
      */
     constructor(number, position, size = 0, partition = 0) {
         super(4);
@@ -67,7 +67,7 @@ class Entry extends Array {
     }
 
     /**
-     * @return {Number} The byte size of this Entry. Always 16.
+     * @returns {number} The byte size of this Entry. Always 16.
      */
     static get size() {
         return 4 * 4;
@@ -77,8 +77,8 @@ class Entry extends Array {
      * Read a new Entry from a Buffer object at the given offset.
      *
      * @param {Buffer} buffer The buffer object to read the index data from. Will read four 32-Bit LE unsigned integers. 
-     * @param {Number} [offset] The buffer offset to start reading from. Default 0.
-     * @return {Entry} A new entry matching the values from the Buffer.
+     * @param {number} [offset] The buffer offset to start reading from. Default 0.
+     * @returns {Entry} A new entry matching the values from the Buffer.
      */
     static fromBuffer(buffer, offset = 0) {
         const number     = buffer.readUInt32LE(offset);
@@ -92,8 +92,8 @@ class Entry extends Array {
      * Write this Entry into a Buffer object at the given offset.
      *
      * @param {Buffer} buffer The buffer object to write the index entry data to. Will write four 32-Bit LE unsigned integers.
-     * @param {Number} offset The offset to start writing into the buffer.
-     * @return {Number} The size of the data written. Will always be 16.
+     * @param {number} offset The offset to start writing into the buffer.
+     * @returns {number} The size of the data written. Will always be 16.
      */
     toBuffer(buffer, offset) {
         buffer.writeUInt32LE(this[0], offset);
@@ -104,28 +104,28 @@ class Entry extends Array {
     }
 
     /**
-     * @returns {Number}
+     * @returns {number}
      */
     get number() {
         return this[0];
     }
 
     /**
-     * @returns {Number}
+     * @returns {number}
      */
     get position() {
         return this[1];
     }
 
     /**
-     * @returns {Number}
+     * @returns {number}
      */
     get size() {
         return this[2];
     }
 
     /**
-     * @returns {Number}
+     * @returns {number}
      */
     get partition() {
         return this[3];

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -62,7 +62,7 @@ class JoinEventStream extends EventStream {
 
     /**
      * @private
-     * @returns {Object|boolean} The next event or false if no more events in the stream.
+     * @returns {object|boolean} The next event or false if no more events in the stream.
      */
     next() {
         let nextIndex = -1;

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -54,7 +54,7 @@ class ReadablePartition extends EventEmitter {
 
     /**
      * @param {string} name The name of the partition.
-     * @param {Object} [config] An object with storage parameters.
+     * @param {object} [config] An object with storage parameters.
      * @param {string} [config.dataDirectory] The path where the storage data should reside. Default '.'.
      * @param {number} [config.readBufferSize] Size of the read buffer in bytes. Default 4096.
      */
@@ -227,7 +227,7 @@ class ReadablePartition extends EventEmitter {
 
         const sequenceNumber = buffer.readUInt32BE(offset + 4);
         const time64 = buffer.readDoubleBE(offset + 8);
-        return { dataSize, sequenceNumber, time64 };
+        return ({ dataSize, sequenceNumber, time64 });
     }
 
     /**
@@ -292,7 +292,7 @@ class ReadablePartition extends EventEmitter {
 
     /**
      * @api
-     * @return {Generator} A generator that returns all documents in this partition.
+     * @returns {Generator} A generator that returns all documents in this partition.
      */
     *readAll() {
         let position = 0;

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -28,14 +28,14 @@ class WritablePartition extends ReadablePartition {
 
     /**
      * @param {string} name The name of the partition.
-     * @param {Object} [config] An object with storage parameters.
+     * @param {object} [config] An object with storage parameters.
      * @param {string} [config.dataDirectory] The path where the storage data should reside. Default '.'.
      * @param {number} [config.readBufferSize] Size of the read buffer in bytes. Default 4096.
      * @param {number} [config.writeBufferSize] Size of the write buffer in bytes. Default 16384.
      * @param {number} [config.maxWriteBufferDocuments] How many documents to have in the write buffer at max. 0 means as much as possible. Default 0.
      * @param {boolean} [config.syncOnFlush] If fsync should be called on write buffer flush. Set this if you need strict durability. Defaults to false.
      * @param {boolean} [config.dirtyReads] If dirty reads should be allowed. This means that writes that are in write buffer but not yet flushed can be read. Defaults to true.
-     * @param {Object} [config.metadata] A metadata object that will be written to the file header.
+     * @param {object} [config.metadata] A metadata object that will be written to the file header.
      * @param {typeof Clock} [config.clock] The constructor to a clock interface
      */
     constructor(name, config = {}) {
@@ -283,7 +283,7 @@ class WritablePartition extends ReadablePartition {
      *
      * @protected
      * @param {number} position The position in the file to prepare the read buffer for reading from.
-     * @returns {Object} A reader object with properties `buffer`, `cursor` and `length`.
+     * @returns {object} A reader object with properties `buffer`, `cursor` and `length`.
      */
     prepareReadBuffer(position) {
         if (position + DOCUMENT_HEADER_SIZE >= this.size) {

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -77,7 +77,7 @@ class ReadOnlyStorage extends ReadableStorage {
      * @protected
      * @param {string} name
      * @param {object} [options]
-     * @returns {{ index: ReadableIndex, matcher?: Object|function }}
+     * @returns {{ index: ReadableIndex, matcher?: object|function }}
      */
     createIndex(name, options = {}) {
         const { index } = super.createIndex(name, options);

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -15,17 +15,17 @@ class ReadableStorage extends EventEmitter {
 
     /**
      * @param {string} [storageName] The name of the storage.
-     * @param {Object} [config] An object with storage parameters.
-     * @param {Object} [config.serializer] A serializer object with methods serialize(document) and deserialize(data).
-     * @param {function(Object): string} config.serializer.serialize Default is JSON.stringify.
-     * @param {function(string): Object} config.serializer.deserialize Default is JSON.parse.
+     * @param {object} [config] An object with storage parameters.
+     * @param {object} [config.serializer] A serializer object with methods serialize(document) and deserialize(data).
+     * @param {function(object): string} config.serializer.serialize Default is JSON.stringify.
+     * @param {function(string): object} config.serializer.deserialize Default is JSON.parse.
      * @param {string} [config.dataDirectory] The path where the storage data should reside. Default '.'.
      * @param {string} [config.indexDirectory] The path where the indexes should be stored. Defaults to dataDirectory.
      * @param {string} [config.indexFile] The name of the primary index. Default '{storageName}.index'.
      * @param {number} [config.readBufferSize] Size of the read buffer in bytes. Default 4096.
-     * @param {Object} [config.indexOptions] An options object that should be passed to all indexes on construction.
+     * @param {object} [config.indexOptions] An options object that should be passed to all indexes on construction.
      * @param {string} [config.hmacSecret] A private key that is used to verify matchers retrieved from indexes.
-     * @param {Object} [config.metadata] A metadata object to be stored in all partitions belonging to this storage.
+     * @param {object} [config.metadata] A metadata object to be stored in all partitions belonging to this storage.
      */
     constructor(storageName = 'storage', config = {}) {
         super();
@@ -58,7 +58,7 @@ class ReadableStorage extends EventEmitter {
      * @protected
      * @param {string} name
      * @param {object} [options]
-     * @returns {{ index: ReadableIndex, matcher?: Object|function }}
+     * @returns {{ index: ReadableIndex, matcher?: object|function }}
      */
     createIndex(name, options = {}) {
         /** @type ReadableIndex */
@@ -80,7 +80,7 @@ class ReadableStorage extends EventEmitter {
      * Create/open the primary index and build the base configuration for all secondary indexes.
      *
      * @private
-     * @param {Object} config The configuration object
+     * @param {object} config The configuration object
      * @returns void
      */
     initializeIndexes(config) {
@@ -108,7 +108,7 @@ class ReadableStorage extends EventEmitter {
      * Every file beginning with the storageFile name is considered a partition.
      *
      * @private
-     * @param {Object} config The configuration object containing options for the partitions.
+     * @param {object} config The configuration object containing options for the partitions.
      * @returns void
      */
     scanPartitions(config) {
@@ -181,7 +181,7 @@ class ReadableStorage extends EventEmitter {
      * @param {number} partitionId The partition to read from.
      * @param {number} position The file position to read from.
      * @param {number} [size] The expected byte size of the document at the given position.
-     * @returns {Object} The document stored at the given position.
+     * @returns {object} The document stored at the given position.
      * @throws {Error} if the document at the given position can not be deserialized.
      */
     readFrom(partitionId, position, size) {
@@ -196,7 +196,7 @@ class ReadableStorage extends EventEmitter {
      * @api
      * @param {number} number The 1-based document number (inside the given index) to read.
      * @param {ReadableIndex} [index] The index to use for finding the document position.
-     * @returns {Object} The document at the given position inside the index.
+     * @returns {object} The document at the given position inside the index.
      */
     read(number, index) {
         index = index || this.index;
@@ -244,7 +244,7 @@ class ReadableStorage extends EventEmitter {
      *
      * @api
      * @param {string} name The index name.
-     * @param {Object|function} [matcher] The matcher object or function that the index needs to have been defined with. If not given it will not be validated.
+     * @param {object|function} [matcher] The matcher object or function that the index needs to have been defined with. If not given it will not be validated.
      * @returns {ReadableIndex}
      * @throws {Error} if the index with that name does not exist.
      * @throws {Error} if the HMAC for the matcher does not match.
@@ -268,7 +268,7 @@ class ReadableStorage extends EventEmitter {
      * Helper method to iterate over all documents.
      *
      * @protected
-     * @param {function(Object, EntryInterface)} iterationHandler
+     * @param {function(object, EntryInterface)} iterationHandler
      */
     forEachDocument(iterationHandler) {
         /* istanbul ignore if  */
@@ -289,7 +289,7 @@ class ReadableStorage extends EventEmitter {
      *
      * @protected
      * @param {function(ReadableIndex, string)} iterationHandler
-     * @param {Object} [matchDocument] If supplied, only indexes the document matches on will be iterated.
+     * @param {object} [matchDocument] If supplied, only indexes the document matches on will be iterated.
      */
     forEachSecondaryIndex(iterationHandler, matchDocument) {
         /* istanbul ignore if  */

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -18,10 +18,10 @@ class WritableStorage extends ReadableStorage {
 
     /**
      * @param {string} [storageName] The name of the storage.
-     * @param {Object} [config] An object with storage parameters.
-     * @param {Object} [config.serializer] A serializer object with methods serialize(document) and deserialize(data).
-     * @param {function(Object): string} config.serializer.serialize Default is JSON.stringify.
-     * @param {function(string): Object} config.serializer.deserialize Default is JSON.parse.
+     * @param {object} [config] An object with storage parameters.
+     * @param {object} [config.serializer] A serializer object with methods serialize(document) and deserialize(data).
+     * @param {function(object): string} config.serializer.serialize Default is JSON.stringify.
+     * @param {function(string): object} config.serializer.deserialize Default is JSON.parse.
      * @param {string} [config.dataDirectory] The path where the storage data should reside. Default '.'.
      * @param {string} [config.indexDirectory] The path where the indexes should be stored. Defaults to dataDirectory.
      * @param {string} [config.indexFile] The name of the primary index. Default '{storageName}.index'.
@@ -30,8 +30,8 @@ class WritableStorage extends ReadableStorage {
      * @param {number} [config.maxWriteBufferDocuments] How many documents to have in the write buffer at max. 0 means as much as possible. Default 0.
      * @param {boolean} [config.syncOnFlush] If fsync should be called on write buffer flush. Set this if you need strict durability. Defaults to false.
      * @param {boolean} [config.dirtyReads] If dirty reads should be allowed. This means that writes that are in write buffer but not yet flushed can be read. Defaults to true.
-     * @param {function(Object, number): string} [config.partitioner] A function that takes a document and sequence number and returns a partition name that the document should be stored in. Defaults to write all documents to the primary partition.
-     * @param {Object} [config.indexOptions] An options object that should be passed to all indexes on construction.
+     * @param {function(object, number): string} [config.partitioner] A function that takes a document and sequence number and returns a partition name that the document should be stored in. Defaults to write all documents to the primary partition.
+     * @param {object} [config.indexOptions] An options object that should be passed to all indexes on construction.
      * @param {string} [config.hmacSecret] A private key that is used to verify matchers retrieved from indexes.
      */
     constructor(storageName = 'storage', config = {}) {
@@ -62,6 +62,7 @@ class WritableStorage extends ReadableStorage {
     /**
      * @inheritDoc
      * @returns {boolean}
+     * @throws {StorageLockedError} If this storage is locked by another process.
      */
     open() {
         if (!this.lock()) {
@@ -73,6 +74,8 @@ class WritableStorage extends ReadableStorage {
     /**
      * Attempt to lock this storage by means of a lock directory.
      * @returns {boolean} True if the lock was created or false if the lock is already in place.
+     * @throws {StorageLockedError} If this storage is already locked by another process.
+     * @throws {Error} If the lock could not be created.
      */
     lock() {
         if (this.locked) {
@@ -119,7 +122,7 @@ class WritableStorage extends ReadableStorage {
      * @param {number} partitionId The partition where the document is stored.
      * @param {number} position The file offset where the document is stored.
      * @param {number} size The size of the stored document.
-     * @param {Object} document The document to add to the index.
+     * @param {object} document The document to add to the index.
      * @param {function} [callback] The callback to call when the index is written to disk.
      * @returns {EntryInterface} The index entry item.
      */
@@ -170,7 +173,7 @@ class WritableStorage extends ReadableStorage {
 
     /**
      * @api
-     * @param {Object} document The document to write to storage.
+     * @param {object} document The document to write to storage.
      * @param {function} [callback] A function that will be called when the document is written to disk.
      * @returns {number} The 1-based document sequence number in the storage.
      */
@@ -202,7 +205,7 @@ class WritableStorage extends ReadableStorage {
      *
      * @api
      * @param {string} name The index name.
-     * @param {Object|function} [matcher] An object that describes the document properties that need to match to add it this index or a function that receives a document and returns true if the document should be indexed.
+     * @param {object|function} [matcher] An object that describes the document properties that need to match to add it this index or a function that receives a document and returns true if the document should be indexed.
      * @returns {ReadableIndex} The index containing all documents that match the query.
      * @throws {Error} if the index doesn't exist yet and no matcher was specified.
      */
@@ -330,7 +333,7 @@ class WritableStorage extends ReadableStorage {
      * @protected
      * @param {string} name
      * @param {object} [options]
-     * @returns {{ index: WritableIndex, matcher: Object|function }}
+     * @returns {{ index: WritableIndex, matcher: object|function }}
      */
     createIndex(name, options = {}) {
         const index = new WritableIndex(name, options);

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -13,7 +13,7 @@ class DirectoryWatcher extends EventEmitter {
 
     /**
      * @param {string} directory
-     * @param {Object} [options] The options to pass to the fs.watch call. See https://nodejs.org/api/fs.html#fs_fs_watch_filename_options_listener
+     * @param {object} [options] The options to pass to the fs.watch call. See https://nodejs.org/api/fs.html#fs_fs_watch_filename_options_listener
      * @returns {DirectoryWatcher}
      */
     constructor(directory, options = {}) {
@@ -33,7 +33,7 @@ class DirectoryWatcher extends EventEmitter {
 
     /**
      * Close this watcher.
-     * @return void
+     * @returns void
      */
     close() {
         this.references--;

--- a/src/util.js
+++ b/src/util.js
@@ -37,8 +37,8 @@ const createHmac = secret => string => {
     };
 
 /**
- * @param {Object} document The document to check against the matcher.
- * @param {Object|function} matcher An object of properties and their values that need to match in the object or a function that checks if the document matches.
+ * @param {object} document The document to check against the matcher.
+ * @param {object|function} matcher An object of properties and their values that need to match in the object or a function that checks if the document matches.
  * @returns {boolean} True if the document matches the matcher or false otherwise.
  */
 function matches(document, matcher) {
@@ -60,7 +60,7 @@ function matches(document, matcher) {
 }
 
 /**
- * @param {Object|function} matcher The matcher object or function that should be serialized.
+ * @param {object|function} matcher The matcher object or function that should be serialized.
  * @param {function(string)} hmac A function that calculates a HMAC of the given string.
  * @returns {{matcher: string|object, hmac?: string}}
  */
@@ -76,9 +76,9 @@ function buildMetadataForMatcher(matcher, hmac) {
 }
 
 /**
- * @param {{matcher: string|Object, hmac: string}} matcherMetadata The serialized matcher and it's HMAC
+ * @param {{matcher: string|object, hmac: string}} matcherMetadata The serialized matcher and it's HMAC
  * @param {function(string)} hmac A function that calculates a HMAC of the given string.
- * @returns {Object|function} The matcher object or function.
+ * @returns {object|function} The matcher object or function.
  */
 function buildMatcherFromMetadata(matcherMetadata, hmac) {
     let matcher;


### PR DESCRIPTION
All types that match typeof should be lower cased. Everything else (Array, Buffer, custom types, ...) capital case.