### PR TITLE
Support reverse streams and range scans

### DIFF
--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -318,7 +318,23 @@ describe('EventStore', function() {
             });
         });
 
-        it('needs to be tested.');
+        it('can iterate events in reverse order', function() {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+
+            for (let i=1; i<=20; i++) {
+                eventstore.commit('foo-bar', [{key: i}]);
+            }
+
+            let reverseStream = eventstore.getEventStream('foo-bar', -1, 0);
+            let i = 20;
+            for (let event of reverseStream) {
+                expect(event).to.eql({ key: i-- });
+            }
+        });
+
+        it('needs to be tested further.');
     });
 
     describe('fromStreams', function() {
@@ -368,6 +384,22 @@ describe('EventStore', function() {
                     });
                 });
             });
+        });
+
+        it('iterates events from multiple streams in reverse order', function() {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+
+            for (let i=1; i<=20; i++) {
+                eventstore.commit(i % 2 ? 'foo' : 'bar', [{key: i}]);
+            }
+
+            let reverseStream = eventstore.fromStreams('foo-bar', ['foo', 'bar'],-1, 0);
+            let i = 20;
+            for (let event of reverseStream) {
+                expect(event).to.eql({ key: i-- });
+            }
         });
 
     });

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -261,6 +261,24 @@ describe('Storage', function() {
             expect(i).to.be(11);
         });
 
+        it('can read full range in reverse', function() {
+            storage = createStorage();
+            storage.open();
+
+            for (let i = 1; i <= 20; i++) {
+                storage.write({ foo: i });
+            }
+            storage.close();
+            storage.open();
+
+            let i = 20;
+            let documents = storage.readRange(i, 1);
+            for (let doc of documents) {
+                expect(doc).to.eql({ foo: i-- });
+            }
+            expect(i).to.be(0);
+        });
+
         it('can read a sub range', function() {
             storage = createStorage();
             storage.open();
@@ -348,7 +366,6 @@ describe('Storage', function() {
             expect(() => storage.readRange(0).next()).to.throwError();
             expect(() => storage.readRange(11).next()).to.throwError();
             expect(() => storage.readRange(1, 14).next()).to.throwError();
-            expect(() => storage.readRange(8, 4).next()).to.throwError();
         });
 
         it('can open secondary indexes lazily', function() {


### PR DESCRIPTION
This allows to iterate streams in reverse order by specifying a reverse order of min and max revision `eventstore.getEventStream('my-stream', 50, 0)`. This also works for joined streams via `fromStream(...)` and directly on the storage layer, e.g. `storage.readRange(50, 0)`.

This is achieved by reading small batches of documents from the storage and iterating them backwards in order to gain from read buffer "hits". Currently the batch size is 10, but should probably be configurable. Optimal batch size is somewhere around how many documents fit into the read buffer.

Resolves #75