### PR TITLE
Allow overriding commitVersion on single event commit

### DIFF
--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -200,6 +200,10 @@ class EventStore extends EventEmitter {
             throw new OptimisticConcurrencyError(`Optimistic Concurrency error. Expected stream "${streamName}" at version ${expectedVersion} but is at version ${streamVersion}.`);
         }
 
+        if (events.length > 1) {
+            delete metadata.commitVersion;
+        }
+
         const commitId = this.length;
         let commitVersion = 0;
         const committedAt = Date.now();
@@ -216,7 +220,7 @@ class EventStore extends EventEmitter {
             callback(commit);
         };
         for (let event of events) {
-            const eventMetadata = Object.assign({ commitId, committedAt }, metadata, { commitVersion, streamVersion });
+            const eventMetadata = Object.assign({ commitId, committedAt, commitVersion }, metadata, { streamVersion });
             const storedEvent = { stream: streamName, payload: event, metadata: eventMetadata };
             commitVersion++;
             streamVersion++;

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -75,7 +75,7 @@ class EventStream extends stream.Readable {
      * Iterate over the events in this stream with a callback.
      * This method is useful to gain access to the event metadata.
      *
-     * @param {function(object, Object, string)} callback A callback function that will receive the event, the storage metadata and the original stream name for every event in this stream.
+     * @param {function(object, object, string)} callback A callback function that will receive the event, the storage metadata and the original stream name for every event in this stream.
      */
     forEach(callback) {
         let next;


### PR DESCRIPTION
This allows easier rewriting of streams without having to manually rebuild the commit event batch.

```javascript
const stream = eventstore.getEventStream('my-stream');
stream.forEach((event, metadata, streamName) => {
   eventstore.commit('my-new-stream', [event], metadata);
});
```

Resolves #118
Related to #116 