### PR TITLE
Make indexes more robust

### DIFF
--- a/test/Index.spec.js
+++ b/test/Index.spec.js
@@ -109,11 +109,12 @@ describe('Index', function() {
         expect(() => index = createIndex(index.name, { metadata: { test: 'anotherValue' } })).to.throwError(/Index metadata mismatch/);
     });
 
-    it('throws on opening with altered file', function() {
+    it('truncates on opening with altered file', function() {
         index = setupIndexWithEntries(5);
         index.close();
         fs.appendFileSync(index.fileName, 'foo');
-        expect(() => index = createIndex(index.name)).to.throwError(/Index file is corrupt/);
+        expect(() => index = createIndex(index.name)).to.not.throwError();
+        expect(index.length).to.be(5);
     });
 
     describe('Entry', function() {


### PR DESCRIPTION
This truncates indexes to valid lengths as long as the file header is valid.

Note though, that this can potentially hide missing index updates at this low level. This case will be dealt with by the higher storage layer or eventstore layer, since the index on itself can not act upon this.

Related to #31 