### PR TITLE
Consumer improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ check of the commit will prevent the second attempt from persisting those events
 already carry the last known version of the guard that the user made a decision on. Otherwise, the guard's own position makes sure
 that only events directly following the previous state are committed.
 
+**Note**
+> This implementation of a consistency guard already implements snapshotting automatically, which means that restarting the process
+> does not require rebuilding the state from all previous events. If you want to control how often the guard's state is snapshotted,
+> you can specify a second argument to the `setState()` method that should be true when a snapshot should be created and false otherwise,
+> e.g. `this.position % 20 === 0`. Note that this is only needed for very high frequency guards/streams, in order to reduce IO.
+
 ### Read-Only
 
 The `EventStore` can also be opened in a readonly mode since 0.7, by specifying the constructor option `readOnly: true`.

--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -125,6 +125,7 @@ class Consumer extends stream.Readable {
             return;
         }
 
+        /* istanbul ignore if */
         if (this.position !== position - 1) {
             return;
         }

--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -8,7 +8,7 @@ const Storage = require('./Storage/ReadableStorage');
 const MAX_CATCHUP_BATCH = 10;
 
 /**
- * Implements an event-driven durable Consumer that provides at-least-once delivery semantics.
+ * Implements an event-driven durable Consumer that provides at-least-once delivery semantics or exactly-once processing semantics if only using setState().
  */
 class Consumer extends stream.Readable {
 
@@ -16,9 +16,10 @@ class Consumer extends stream.Readable {
      * @param {Storage} storage The storage to create the consumer for.
      * @param {string} indexName The name of the index to consume.
      * @param {string} identifier The unique name to identify this consumer.
+     * @param {object} [initialState] The initial state of the consumer.
      * @param {number} [startFrom] The revision to start from within the index to consume.
      */
-    constructor(storage, indexName, identifier, startFrom = 0) {
+    constructor(storage, indexName, identifier, initialState = {}, startFrom = 0) {
         super({ objectMode: true });
 
         assert(storage instanceof Storage, 'Must provide a storage for the consumer.');
@@ -26,7 +27,7 @@ class Consumer extends stream.Readable {
         assert(typeof identifier === 'string' && identifier !== '', 'Must specify an identifier name for the consumer.');
 
         this.initializeStorage(storage, indexName, identifier);
-        this.restoreState(startFrom);
+        this.restoreState(initialState, startFrom);
         this.handler = this.handleNewDocument.bind(this);
         this.on('error', () => (this.handleDocument = false));
     }
@@ -67,12 +68,17 @@ class Consumer extends stream.Readable {
 
     /**
      * @private
+     * @param {object} initialState The initial state if no persisted state exists.
      * @param {number} startFrom The revision to start from within the index to consume.
      */
-    restoreState(startFrom) {
+    restoreState(initialState, startFrom) {
         /* istanbul ignore if */
         if (!this.fileName) {
             return;
+        }
+        if (typeof initialState === 'number') {
+            startFrom = initialState;
+            initialState = {};
         }
         try {
             const consumerData = fs.readFileSync(this.fileName);
@@ -80,8 +86,9 @@ class Consumer extends stream.Readable {
             this.state = JSON.parse(consumerData.toString('utf8', 4));
         } catch (e) {
             this.position = startFrom;
-            this.state = {};
+            this.state = initialState;
         }
+        Object.freeze(this.state);
 
         this.persisting = null;
         this.consuming = false;
@@ -91,13 +98,18 @@ class Consumer extends stream.Readable {
      * Update the state of this consumer transactionally with the position.
      * May only be called from within the document handling callback.
      *
-     * @param {object} newState
+     * @param {object|function(object):object} newState
+     * @param {boolean} [persist] Set to false if this state update should not be persisted yet
      * @api
      */
-    setState(newState) {
+    setState(newState, persist = true) {
         assert(this.handleDocument, 'Called setState outside of document handler!');
 
+        if (typeof newState === 'function') {
+            newState = newState(this.state);
+        }
         this.state = Object.freeze(newState);
+        this.doPersist = persist;
     }
 
     /**
@@ -123,7 +135,9 @@ class Consumer extends stream.Readable {
             this.stop();
         }
         this.position = position;
-        this.persist();
+        if (this.doPersist) {
+            this.persist();
+        }
     }
 
     /**
@@ -235,6 +249,23 @@ class Consumer extends stream.Readable {
         this.storage.removeListener('index-add', this.handler);
         this.consuming = false;
         this.handleDocument = false;
+    }
+
+    /**
+     * Reset this projection to restart processing all documents again.
+     * NOTE: This will overwrite the current state of the projection and hence be destructive.
+     * @param {number} [startFrom] The revision to start from within the index to consume.
+     * @api
+     */
+    reset(startFrom = 0) {
+        const restart = this.consuming;
+        this.stop();
+        this.state = Object.freeze({});
+        this.position = startFrom;
+        this.persist();
+        if (restart) {
+            this.start();
+        }
     }
 
     /**

--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -168,7 +168,10 @@ class Consumer extends stream.Readable {
                 this.emit('persisted');
             } catch (e) {
                 /* istanbul ignore next */
-                fs.unlinkSync(tmpFile);
+                try {
+                    fs.unlinkSync(tmpFile);
+                } catch (e) {
+                }
             }
         });
     }

--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -254,13 +254,18 @@ class Consumer extends stream.Readable {
     /**
      * Reset this projection to restart processing all documents again.
      * NOTE: This will overwrite the current state of the projection and hence be destructive.
+     * @param {object} [initialState] The initial state of the consumer.
      * @param {number} [startFrom] The revision to start from within the index to consume.
      * @api
      */
-    reset(startFrom = 0) {
+    reset(initialState = {}, startFrom = 0) {
+        if (typeof initialState === 'number') {
+            startFrom = initialState;
+            initialState = {};
+        }
         const restart = this.consuming;
         this.stop();
-        this.state = Object.freeze({});
+        this.state = Object.freeze(initialState);
         this.position = startFrom;
         this.persist();
         if (restart) {

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -365,11 +365,12 @@ class EventStore extends EventEmitter {
      *
      * @param {string} streamName The name of the stream to consume.
      * @param {string} identifier The unique identifying name of this consumer.
+     * @param {object} [initialState] The initial state of the consumer.
      * @param {number} [since] The stream revision to start consuming from.
      * @returns {Consumer} A durable consumer for the given stream.
      */
-    getConsumer(streamName, identifier, since = 0) {
-        const consumer = new Consumer(this.storage, 'stream-' + streamName, identifier, since);
+    getConsumer(streamName, identifier, initialState = {}, since = 0) {
+        const consumer = new Consumer(this.storage, 'stream-' + streamName, identifier, initialState, since);
         return consumer.pipe(new EventUnwrapper());
     }
 

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -371,6 +371,7 @@ class EventStore extends EventEmitter {
      */
     getConsumer(streamName, identifier, initialState = {}, since = 0) {
         const consumer = new Consumer(this.storage, 'stream-' + streamName, identifier, initialState, since);
+        consumer.streamName = streamName;
         return consumer.pipe(new EventUnwrapper());
     }
 

--- a/test/Consumer.spec.js
+++ b/test/Consumer.spec.js
@@ -264,6 +264,21 @@ describe('Consumer', function() {
         expect(() => consumer.setState({ foo: 'bar' })).to.throwError();
     });
 
+    it('will persist multiple setState calls only once', function(done) {
+        consumer = new Consumer(storage, 'foobar', 'consumer-1');
+        consumer.on('data', () => {
+            consumer.setState({ foo: 1 });
+            consumer.setState({ foo: 1, bar: 2 });
+            consumer.once('persisted', () => {
+                expect(consumer.state.bar).to.be(2);
+                done();
+            });
+            consumer.stop();
+        });
+
+        storage.write({ type: 'Foobar', id: 1 });
+    });
+
     it('restores state after reopening', function(done) {
         const state = { foo: 0, bar: 'baz' };
         consumer = new Consumer(storage, 'foobar', 'consumer-1');

--- a/test/Consumer.spec.js
+++ b/test/Consumer.spec.js
@@ -342,6 +342,23 @@ describe('Consumer', function() {
         consumer.start();
     });
 
+    it('can be reset while running', function(done) {
+        consumer = new Consumer(storage, 'foobar', 'consumer-1');
+        consumer.once('caught-up', () => {
+            storage.write({ type: 'Foobar', id: 1 });
+            storage.write({ type: 'Foobar', id: 2 });
+            storage.write({ type: 'Foobar', id: 3 });
+        });
+        consumer.once('data', () => {
+            consumer.reset();
+            expect(consumer.position).to.be(0);
+            consumer.once('caught-up', () => {
+                expect(consumer.position).to.be(3);
+                done();
+            });
+        });
+    });
+
     it('persists state on every setState by default', function(done) {
         consumer = new Consumer(storage, 'foobar', 'consumer-1', { foo: 0 });
         let expected = 0;

--- a/test/Consumer.spec.js
+++ b/test/Consumer.spec.js
@@ -374,6 +374,21 @@ describe('Consumer', function() {
         });
     });
 
+    it('will not restart if stopped before reset', function(done) {
+        storage.write({ type: 'Foobar', id: 1 });
+        storage.write({ type: 'Foobar', id: 2 });
+        storage.write({ type: 'Foobar', id: 3 });
+        consumer = new Consumer(storage, 'foobar', 'consumer-1');
+        consumer.once('caught-up', () => {
+            consumer.stop();
+            expect(consumer.isPaused()).to.be(true);
+            consumer.reset();
+            expect(consumer.isPaused()).to.be(true);
+            done();
+        });
+        consumer.start();
+    });
+
     it('persists state on every setState by default', function(done) {
         consumer = new Consumer(storage, 'foobar', 'consumer-1', { foo: 0 });
         let expected = 0;


### PR DESCRIPTION
This adds support for specifying an inital state for consumers, specify a function that receives the previous state as `setState()` argument and allows to reset a consumer, with new inital state and possibly a starting position.
Also, this adds a second parameter to `setState()` that allows to skip the persistence of the state. That way a snapshot can be built that only persists every N events (or any other arbitrary rule).

Resolves #137
Resolves #136
Related to #11 for arbitrary snapshots