### PR TITLE
Correctly recognize indexes stored in different directory in read-only storage

### DIFF
--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -13,6 +13,8 @@ class ReadOnlyStorage extends ReadableStorage {
      */
     constructor(storageName = 'storage', config = {}) {
         super(storageName, config);
+        this.storageFilesFilter = this.storageFilesFilter.bind(this);
+        this.onStorageFileChanged = this.onStorageFileChanged.bind(this);
     }
 
     /**
@@ -33,8 +35,12 @@ class ReadOnlyStorage extends ReadableStorage {
      */
     open() {
         if (!this.watcher) {
-            this.watcher = new Watcher(this.dataDirectory, this.storageFilesFilter.bind(this));
-            this.watcher.on('rename', this.onStorageFileChanged.bind(this));
+            this.watcher = new Watcher(this.dataDirectory, this.storageFilesFilter);
+            this.watcher.on('rename', this.onStorageFileChanged);
+        }
+        if (this.dataDirectory !== this.indexDirectory && !this.indexWatcher) {
+            this.indexWatcher = new Watcher(this.indexDirectory, this.storageFilesFilter);
+            this.indexWatcher.on('rename', this.onStorageFileChanged);
         }
         return super.open();
     }
@@ -45,8 +51,9 @@ class ReadOnlyStorage extends ReadableStorage {
      */
     onStorageFileChanged(filename) {
         if (filename.substr(-6) === '.index') {
+            const indexName = filename.substr(this.storageFile.length + 1, filename.length - this.storageFile.length - 7);
             // New indexes are not automatically opened in the reader
-            this.emit('index-created', filename);
+            this.emit('index-created', indexName);
             return;
         }
 
@@ -69,6 +76,10 @@ class ReadOnlyStorage extends ReadableStorage {
         if (this.watcher) {
             this.watcher.close();
             this.watcher = null;
+        }
+        if (this.indexWatcher) {
+            this.indexWatcher.close();
+            this.indexWatcher = null;
         }
         super.close();
     }

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -35,12 +35,8 @@ class ReadOnlyStorage extends ReadableStorage {
      */
     open() {
         if (!this.watcher) {
-            this.watcher = new Watcher(this.dataDirectory, this.storageFilesFilter);
+            this.watcher = new Watcher([this.dataDirectory, this.indexDirectory], this.storageFilesFilter);
             this.watcher.on('rename', this.onStorageFileChanged);
-        }
-        if (this.dataDirectory !== this.indexDirectory && !this.indexWatcher) {
-            this.indexWatcher = new Watcher(this.indexDirectory, this.storageFilesFilter);
-            this.indexWatcher.on('rename', this.onStorageFileChanged);
         }
         return super.open();
     }
@@ -76,10 +72,6 @@ class ReadOnlyStorage extends ReadableStorage {
         if (this.watcher) {
             this.watcher.close();
             this.watcher = null;
-        }
-        if (this.indexWatcher) {
-            this.indexWatcher.close();
-            this.indexWatcher = null;
         }
         super.close();
     }

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -62,12 +62,11 @@ class Watcher {
     constructor(fileOrDirectory, fileFilter = null) {
         let directories;
         if (typeof fileOrDirectory === 'string') {
+            directories = [fileOrDirectory];
             if (!fs.statSync(fileOrDirectory).isDirectory()) {
                 directories = [path.dirname(fileOrDirectory)];
                 const filename = path.basename(fileOrDirectory);
                 fileFilter = changedFilename => changedFilename === filename;
-            } else {
-                directories = [fileOrDirectory];
             }
         } else {
             directories = [...new Set(fileOrDirectory.map(path.normalize))];

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -3,6 +3,7 @@ const path = require('path');
 const events = require('events');
 const { assert } = require('./util');
 
+/** @type {Map<string, DirectoryWatcher>} */
 const directoryWatchers = new Map();
 
 /**
@@ -18,13 +19,14 @@ class DirectoryWatcher extends events.EventEmitter {
      */
     constructor(directory, options = {}) {
         directory = path.normalize(directory);
-        assert(fs.existsSync(directory), 'Can not watch a non-existing directory.');
 
         if (directoryWatchers.has(directory)) {
             const watcher = directoryWatchers.get(directory);
             watcher.references++;
             return watcher;
         }
+        assert(fs.existsSync(directory), `Can not watch a non-existing directory "${directory}".`);
+        assert(fs.statSync(directory).isDirectory(), `Can only watch directories, but "${directory}" is none.`);
         super();
         directoryWatchers.set(directory, this);
         this.directory = directory;
@@ -53,30 +55,37 @@ class DirectoryWatcher extends events.EventEmitter {
 class Watcher {
 
     /**
-     * @param {string} fileOrDirectory
-     * @param {function(string): boolean} [fileFilter] A filter that will receive a filename and needs to return true if this watcher should be invoked.
+     * @param {string|string[]} fileOrDirectory The filename or directory or list of directories to watch
+     * @param {function(string): boolean} [fileFilter] A filter that will receive a filename and needs to return true if this watcher should be invoked. Will be ignored if the first argument is a file.
      * @returns {Watcher}
      */
     constructor(fileOrDirectory, fileFilter = null) {
-        const isDirectory = fs.statSync(fileOrDirectory).isDirectory();
-        let directory = fileOrDirectory;
-        if (!isDirectory) {
-            directory = path.dirname(fileOrDirectory);
+        let directories;
+        if (typeof fileOrDirectory === 'string') {
+            if (!fs.statSync(fileOrDirectory).isDirectory()) {
+                directories = [path.dirname(fileOrDirectory)];
+                const filename = path.basename(fileOrDirectory);
+                fileFilter = changedFilename => changedFilename === filename;
+            } else {
+                directories = [fileOrDirectory];
+            }
+        } else {
+            directories = [...new Set(fileOrDirectory.map(path.normalize))];
         }
-        this.watcher = new DirectoryWatcher(directory);
 
-        if (!isDirectory) {
-            const filename = path.basename(fileOrDirectory);
-            fileFilter = changedFilename => changedFilename === filename;
-        } else if (fileFilter === null) {
+        this.watchers = directories.map(dir => new DirectoryWatcher(dir));
+
+        if (fileFilter === null) {
             fileFilter = () => true;
         }
 
         this.fileFilter = fileFilter;
         this.onChange = this.onChange.bind(this);
         this.onRename = this.onRename.bind(this);
-        this.watcher.on('change', this.onChange);
-        this.watcher.on('rename', this.onRename);
+        this.watchers.forEach(watcher => {
+            watcher.on('change', this.onChange);
+            watcher.on('rename', this.onRename);
+        });
         this.handlers = { change: [], rename: [] };
     }
 
@@ -127,13 +136,12 @@ class Watcher {
      * @api
      */
     close() {
-        if (!(this.watcher instanceof events.EventEmitter)) {
-            return;
-        }
-        this.watcher.removeListener('change', this.onChange);
-        this.watcher.removeListener('rename', this.onRename);
-        this.watcher.close();
-        this.watcher = null;
+        this.watchers.forEach(watcher => {
+            watcher.removeListener('change', this.onChange);
+            watcher.removeListener('rename', this.onRename);
+            watcher.close();
+        });
+        this.watchers = [];
         this.handlers = { change: [], rename: [] };
     }
 

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -867,7 +867,24 @@ describe('Storage', function() {
             let reader = createReader();
             reader.open();
             reader.on('index-created', (name) => {
-                expect(name.substr(-9, 3)).to.be('one');
+                expect(name).to.be('one');
+                expect(reader.secondaryIndexes[name]).to.be(undefined);
+                reader.close();
+                done();
+            });
+
+            storage.ensureIndex('one', doc => doc.type === 'one');
+            storage.flush();
+        });
+
+        it('recognizes new indexes created in different directory by writer', function(done){
+            storage = createStorage({ indexDirectory: dataDirectory + '/indexes', syncOnFlush: true, partitioner:  (document, number) => document.type });
+            storage.open();
+
+            let reader = createReader( { indexDirectory: dataDirectory + '/indexes' });
+            reader.open();
+            reader.on('index-created', (name) => {
+                expect(name).to.be('one');
                 expect(reader.secondaryIndexes[name]).to.be(undefined);
                 reader.close();
                 done();


### PR DESCRIPTION
Until now indexes that were created in a different directory than the data storage were not recognized by the watcher in the read-only storage. This fixes that by adding a separate watcher for the index directory if it differs from the data directory.
Also the arguments of the `index-created` event on read-only storages was different from the write storage, as it contained the full filename.