### PR TITLE
Fix matcher with undefined property checks

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -52,7 +52,7 @@ function matches(document, matcher) {
             if (!matches(document[prop], matcher[prop])) {
                 return false;
             }
-        } else if (document[prop] !== matcher[prop]) {
+        } else if (typeof matcher[prop] !== 'undefined' && document[prop] !== matcher[prop]) {
             return false;
         }
     }

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -429,6 +429,19 @@ describe('Storage', function() {
             expect(index.length).to.be(1);
         });
 
+        it('indexes documents by property object matcher ignoring undefined properties', function(done) {
+            storage = createStorage();
+            storage.open();
+            storage.write({type: 'Bar', other: '1'});
+            storage.write({type: 'Foo', other: '2'});
+            storage.write({type: 'Baz', other: '3'}, () => {
+                let index = storage.ensureIndex('foo', {type: 'Foo', other: undefined});
+
+                expect(index.length).to.be(1);
+                done();
+            });
+        });
+
         it('reopens existing indexes', function() {
             storage = createStorage();
             storage.open();


### PR DESCRIPTION
Previously, an object matcher that contained an undefined property would not match documents that contained that property, but only during the run of the creation. Once the index was reopened, the matcher would work as expected, because the undefined matcher property was not serialized into the index.
This change fixes that by correctly ignoring matcher properties that are `undefined` (e.g. when deleting a property from an object).