### PR TITLE
Separate documents by a unique sequence and make partition backwards scannable

### DIFF
--- a/src/Partition/ReadOnlyPartition.js
+++ b/src/Partition/ReadOnlyPartition.js
@@ -18,6 +18,7 @@ class ReadOnlyPartition extends WatchesFile(ReadablePartition) {
      * @param {string} filename
      */
     onChange(filename) {
+        /* istanbul ignore if */
         if (!this.fd) {
             return;
         }

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -7,17 +7,18 @@ const Clock = require('../Clock');
 const DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
 const DOCUMENT_HEADER_SIZE = 16;
 const DOCUMENT_ALIGNMENT = 4;
-const DOCUMENT_PAD = ' '.repeat(15) + "\n";
+const DOCUMENT_SEPARATOR = "\x00\x00\x1E\n";
+const DOCUMENT_PAD = ' '.repeat(16 - DOCUMENT_SEPARATOR.length) + DOCUMENT_SEPARATOR;
 
 const NES_EPOCH = new Date('2020-01-01T00:00:00');
 
 /**
  * @param {number} dataSize
- * @returns {string} The data padded to 16 bytes alignment and ended with a line break.
+ * @returns {string} The data padded to 16 bytes alignment and ended with \0x1E (record separator) and a line break.
  */
 function padData(dataSize) {
-    const padSize = (DOCUMENT_ALIGNMENT - ((dataSize + 1) % DOCUMENT_ALIGNMENT)) % DOCUMENT_ALIGNMENT;
-    return DOCUMENT_PAD.substr(-padSize - 1);
+    const padSize = (DOCUMENT_ALIGNMENT - ((dataSize + DOCUMENT_SEPARATOR.length) % DOCUMENT_ALIGNMENT)) % DOCUMENT_ALIGNMENT;
+    return DOCUMENT_PAD.substr(-padSize - DOCUMENT_SEPARATOR.length);
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -27,6 +27,17 @@ function assert(condition, message, ErrorType = Error) {
 }
 
 /**
+ * Return the amount required to align value to the given alignment.
+ * It calculates the difference of the alignment and the modulo of value by alignment.
+ * @param {number} value
+ * @param {number} alignment
+ * @returns {number}
+ */
+function alignTo(value, alignment) {
+    return (alignment - (value % alignment)) % alignment;
+}
+
+/**
  * @param {string} secret The secret to use for calculating further HMACs
  * @returns {function(string)} A function that calculates the HMAC for a given string
  */
@@ -177,5 +188,6 @@ module.exports = {
     matches,
     buildMetadataForMatcher,
     buildMatcherFromMetadata,
-    buildMetadataHeader
+    buildMetadataHeader,
+    alignTo
 };

--- a/test/Partition.spec.js
+++ b/test/Partition.spec.js
@@ -26,8 +26,8 @@ describe('Partition', function() {
     /**
      * @returns {ReadOnlyPartition}
      */
-    function createReader() {
-        const reader = new Partition.ReadOnly(partition.name, { dataDirectory });
+    function createReader(options = {}) {
+        const reader = new Partition.ReadOnly(partition.name, { ...options, dataDirectory });
         readers[readers.length] = reader;
         return reader;
     }
@@ -152,6 +152,80 @@ describe('Partition', function() {
                 expect(data).to.be('foo-' + i.toString());
                 i++;
             }
+        });
+
+    });
+
+    describe('readAll', function() {
+
+        it('reads all documents in write order', function() {
+            partition.open();
+            fillPartition(50, i => 'foo-' + i.toString());
+            partition.close();
+            partition.open();
+            let i = 1;
+            for (let data of partition.readAll()) {
+                expect(data).to.be('foo-' + i.toString());
+                i++;
+            }
+            expect(i).to.be(51);
+        });
+
+        it('reads all documents in write order from arbitrary position', function() {
+            partition.open();
+            fillPartition(50, i => 'foo-' + i.toString());
+            partition.close();
+            partition.open();
+            let i = 50;
+            for (let data of partition.readAll(-partition.documentWriteSize('foo-50'.length)-1)) {
+                expect(data).to.be('foo-' + i.toString());
+                i++;
+            }
+            expect(i).to.be(51);
+        });
+
+        it('reads all documents in backwards write order', function() {
+            partition.open();
+            fillPartition(50, i => 'foo-' + i.toString());
+            partition.close();
+            partition.open();
+            let i = 50;
+            for (let data of partition.readAllBackwards()) {
+                expect(data).to.be('foo-' + i.toString());
+                i--;
+            }
+            expect(i).to.be(0);
+        });
+
+        it('reads all documents in backwards write order from arbitary position', function() {
+            partition.open();
+            fillPartition(50, i => 'foo-' + i.toString());
+            partition.close();
+            partition.open();
+            let i = 50;
+            for (let data of partition.readAllBackwards(-9)) {
+                expect(data).to.be('foo-' + i.toString());
+                i--;
+            }
+            expect(i).to.be(0);
+            i = 50;
+            for (let data of partition.readAllBackwards(partition.size - 12)) {
+                expect(data).to.be('foo-' + i.toString());
+                i--;
+            }
+            expect(i).to.be(0);
+        });
+
+        it('can find document boundaries by scanning across readbuffers', function() {
+            partition.open();
+            fillPartition(2, i => '0xFF'.repeat(64));
+            const lastPosition = partition.write('0xFF'.repeat(64));
+            partition.close();
+
+            const reader = createReader({ readBufferSize: 64 });
+            reader.open();
+            expect(reader.findDocumentPositionBefore(reader.size - 8)).to.be(lastPosition);
+            reader.close();
         });
 
     });


### PR DESCRIPTION
This exchanges the `\n` (newline) document separator with the sequence `\x00\x00\x1E\n`, which is distinguishing enough to be searchable in the partition. Hence, this will allow checking for unfinished writes and search the last valid document and even scan through the partition backwards.
For optimization of that use case, the document data size is stored again before the document separator.

Resolves #124 
Related to #31 #107  