### PR TITLE
Newly created streams are recognized in read-only EventStore

### DIFF
--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -120,13 +120,15 @@ class EventStore extends events.EventEmitter {
 
     /**
      * @private
-     * @param {string} name
+     * @param {string} name The full stream name, including the `stream-` prefix.
      */
     registerStream(name) {
+        /* istanbul ignore if */
         if (!name.startsWith('stream-')) {
             return;
         }
         const streamName = name.substr(7, name.length - 7);
+        /* istanbul ignore if */
         if (streamName in this.streams) {
             return;
         }

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -119,6 +119,18 @@ class EventStore extends events.EventEmitter {
             }
             callback();
         });
+        this.storage.on('index-created', name => {
+            if (!name.startsWith('stream-')) {
+                return;
+            }
+            const streamName = name.substr(7, name.length - 7);
+            if (streamName in this.streams) {
+                return;
+            }
+            const index = this.storage.openIndex('stream-'+streamName);
+            this.streams[streamName] = { index };
+            this.emit('stream-available', streamName);
+        });
     }
 
     /**

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -131,7 +131,7 @@ class EventStore extends events.EventEmitter {
             return;
         }
         const index = this.storage.openIndex('stream-'+streamName);
-        // deepcode ignore PrototypePollution: streams is a Map
+        // deepcode ignore PrototypePollutionFunctionParams: streams is a Map
         this.streams[streamName] = { index };
         this.emit('stream-available', streamName);
     }
@@ -350,6 +350,7 @@ class EventStore extends events.EventEmitter {
         const index = this.storage.ensureIndex(streamIndexName, matcher);
         assert(index !== null, `Error creating stream index ${streamName}.`);
 
+        // deepcode ignore PrototypePollutionFunctionParams: streams is a Map
         this.streams[streamName] = { index, matcher };
         this.emit('stream-created', streamName);
         return new EventStream(streamName, this);

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -20,6 +20,10 @@ function *reverse(iterator) {
 }
 
 /**
+ * @typedef {object|function(object):boolean} Matcher
+ */
+
+/**
  * An append-only storage with highly performant positional range scans.
  * It's highly optimized for an event-store and hence does not support compaction or data-rewrite, nor any querying
  */
@@ -70,7 +74,7 @@ class ReadableStorage extends events.EventEmitter {
      * @protected
      * @param {string} name
      * @param {object} [options]
-     * @returns {{ index: ReadableIndex, matcher?: object|function }}
+     * @returns {{ index: ReadableIndex, matcher?: Matcher }}
      */
     createIndex(name, options = {}) {
         /** @type ReadableIndex */
@@ -278,7 +282,7 @@ class ReadableStorage extends events.EventEmitter {
      *
      * @api
      * @param {string} name The index name.
-     * @param {object|function} [matcher] The matcher object or function that the index needs to have been defined with. If not given it will not be validated.
+     * @param {Matcher} [matcher] The matcher object or function that the index needs to have been defined with. If not given it will not be validated.
      * @returns {ReadableIndex}
      * @throws {Error} if the index with that name does not exist.
      * @throws {Error} if the HMAC for the matcher does not match.

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -11,6 +11,10 @@ const DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
 class StorageLockedError extends Error {}
 
 /**
+ * @typedef {object|function(object):boolean} Matcher
+ */
+
+/**
  * An append-only storage with highly performant positional range scans.
  * It's highly optimized for an event-store and hence does not support compaction or data-rewrite, nor any querying
  */
@@ -205,7 +209,7 @@ class WritableStorage extends ReadableStorage {
      *
      * @api
      * @param {string} name The index name.
-     * @param {object|function} [matcher] An object that describes the document properties that need to match to add it this index or a function that receives a document and returns true if the document should be indexed.
+     * @param {Matcher} [matcher] An object that describes the document properties that need to match to add it this index or a function that receives a document and returns true if the document should be indexed.
      * @returns {ReadableIndex} The index containing all documents that match the query.
      * @throws {Error} if the index doesn't exist yet and no matcher was specified.
      */
@@ -333,7 +337,7 @@ class WritableStorage extends ReadableStorage {
      * @protected
      * @param {string} name
      * @param {object} [options]
-     * @returns {{ index: WritableIndex, matcher: object|function }}
+     * @returns {{ index: WritableIndex, matcher: Matcher }}
      */
     createIndex(name, options = {}) {
         const index = new WritableIndex(name, options);

--- a/src/util.js
+++ b/src/util.js
@@ -37,8 +37,12 @@ const createHmac = secret => string => {
     };
 
 /**
+ * @typedef {object|function(object):boolean} Matcher
+ */
+
+/**
  * @param {object} document The document to check against the matcher.
- * @param {object|function} matcher An object of properties and their values that need to match in the object or a function that checks if the document matches.
+ * @param {Matcher} matcher An object of properties and their values that need to match in the object or a function that checks if the document matches.
  * @returns {boolean} True if the document matches the matcher or false otherwise.
  */
 function matches(document, matcher) {
@@ -60,7 +64,7 @@ function matches(document, matcher) {
 }
 
 /**
- * @param {object|function} matcher The matcher object or function that should be serialized.
+ * @param {Matcher} matcher The matcher object or function that should be serialized.
  * @param {function(string)} hmac A function that calculates a HMAC of the given string.
  * @returns {{matcher: string|object, hmac?: string}}
  */
@@ -78,7 +82,7 @@ function buildMetadataForMatcher(matcher, hmac) {
 /**
  * @param {{matcher: string|object, hmac: string}} matcherMetadata The serialized matcher and it's HMAC
  * @param {function(string)} hmac A function that calculates a HMAC of the given string.
- * @returns {object|function} The matcher object or function.
+ * @returns {Matcher} The matcher object or function.
  */
 function buildMatcherFromMetadata(matcherMetadata, hmac) {
     let matcher;

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -348,6 +348,29 @@ describe('EventStore', function() {
             }
         });
 
+        it('can open streams created in writer', function(done) {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+
+            const readstore = new EventStore({
+                storageDirectory,
+                readOnly: true
+            });
+
+            expect(readstore.getStreamVersion('foo')).to.be(-1);
+
+            readstore.on('stream-available', (streamName) => {
+                if (streamName === 'foo') {
+                    expect(readstore.getStreamVersion('foo')).to.be(0);
+                    readstore.close();
+                    done();
+                }
+            });
+
+            eventstore.createEventStream('foo', { type: 'foo' });
+        });
+
         it('needs to be tested further.');
     });
 


### PR DESCRIPTION
Until now a read-only EventStore would not recognize streams that are created while it is running. Therefore a `getEventStream()` for such a stream would return `false`.
This fixes that by listening to the storage `index-created` event and registering the according stream.