### PR TITLE
Add support for reading partition backwards

### DIFF
--- a/src/Partition/ReadOnlyPartition.js
+++ b/src/Partition/ReadOnlyPartition.js
@@ -18,6 +18,7 @@ class ReadOnlyPartition extends WatchesFile(ReadablePartition) {
      * @param {string} filename
      */
     onChange(filename) {
+        /* istanbul ignore if */
         if (!this.fd) {
             return;
         }

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -1,12 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 const events = require('events');
-const { assert } = require('../util');
+const { assert, alignTo } = require('../util');
 
 const DEFAULT_READ_BUFFER_SIZE = 64 * 1024;
 const DOCUMENT_HEADER_SIZE = 16;
 const DOCUMENT_ALIGNMENT = 4;
 const DOCUMENT_SEPARATOR = "\x00\x00\x1E\n";
+const DOCUMENT_FOOTER_SIZE = 4 /* additional data size footer */ + DOCUMENT_SEPARATOR.length;
 
 // node-event-store partition V03
 const HEADER_MAGIC = "nesprt03";
@@ -161,8 +162,8 @@ class ReadablePartition extends events.EventEmitter {
      * @returns {number} The size of the data including header, padded to 16 bytes alignment and ended with a line break.
      */
     documentWriteSize(dataSize) {
-        const padSize = (DOCUMENT_ALIGNMENT - ((dataSize + 4 + DOCUMENT_SEPARATOR.length) % DOCUMENT_ALIGNMENT)) % DOCUMENT_ALIGNMENT;
-        return dataSize + DOCUMENT_SEPARATOR.length + 4 + padSize + DOCUMENT_HEADER_SIZE;
+        const padSize = alignTo(dataSize + DOCUMENT_FOOTER_SIZE, DOCUMENT_ALIGNMENT);
+        return DOCUMENT_HEADER_SIZE + dataSize + padSize + DOCUMENT_FOOTER_SIZE;
     }
 
     /**
@@ -383,3 +384,7 @@ module.exports = ReadablePartition;
 module.exports.CorruptFileError = CorruptFileError;
 module.exports.InvalidDataSizeError = InvalidDataSizeError;
 module.exports.HEADER_MAGIC = HEADER_MAGIC;
+module.exports.DOCUMENT_SEPARATOR = DOCUMENT_SEPARATOR;
+module.exports.DOCUMENT_ALIGNMENT = DOCUMENT_ALIGNMENT;
+module.exports.DOCUMENT_HEADER_SIZE = DOCUMENT_HEADER_SIZE;
+module.exports.DOCUMENT_FOOTER_SIZE = DOCUMENT_FOOTER_SIZE;

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -161,8 +161,8 @@ class ReadablePartition extends events.EventEmitter {
      * @returns {number} The size of the data including header, padded to 16 bytes alignment and ended with a line break.
      */
     documentWriteSize(dataSize) {
-        const padSize = (DOCUMENT_ALIGNMENT - ((dataSize + DOCUMENT_SEPARATOR.length) % DOCUMENT_ALIGNMENT)) % DOCUMENT_ALIGNMENT;
-        return dataSize + DOCUMENT_SEPARATOR.length + padSize + DOCUMENT_HEADER_SIZE;
+        const padSize = (DOCUMENT_ALIGNMENT - ((dataSize + 4 + DOCUMENT_SEPARATOR.length) % DOCUMENT_ALIGNMENT)) % DOCUMENT_ALIGNMENT;
+        return dataSize + DOCUMENT_SEPARATOR.length + 4 + padSize + DOCUMENT_HEADER_SIZE;
     }
 
     /**
@@ -328,12 +328,12 @@ class ReadablePartition extends events.EventEmitter {
 
         const separatorSize = DOCUMENT_SEPARATOR.length;
         // Optimization if we are at an exact document boundary, where we can just read the document size
-        let reader/* = this.prepareReadBufferBackwards(position);
+        let reader = this.prepareReadBufferBackwards(position);
         const block = reader.buffer.toString('ascii', reader.cursor - separatorSize, reader.cursor);
         if (block === DOCUMENT_SEPARATOR) {
             const dataSize = reader.buffer.readUInt32BE(reader.cursor - separatorSize - 4);
             return position - this.documentWriteSize(dataSize);
-        }*/
+        }
 
         do {
             reader = this.prepareReadBufferBackwards(position - separatorSize);

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -347,8 +347,6 @@ class ReadablePartition extends events.EventEmitter {
             position -= this.readBufferLength;
         } while (position > 0);
         return position;
-        /*const header = this.readDocumentHeader(reader.buffer, reader.cursor, position);
-        return ({ position, ...header });*/
     }
 
     /**

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -209,7 +209,7 @@ class ReadablePartition extends events.EventEmitter {
      * @param {number} offset The position inside the buffer to start reading from.
      * @param {number} position The file position to start reading from.
      * @param {number} [size] The expected byte size of the document at the given position.
-     * @returns {{ dataSize: number, sequenceNumber, number, time64: number }} The metadata fields of the document
+     * @returns {{ dataSize: number, sequenceNumber: number, time64: number }} The metadata fields of the document
      * @throws {Error} if the storage entry at the given position is corrupted.
      * @throws {InvalidDataSizeError} if the document size at the given position does not match the provided size.
      * @throws {CorruptFileError} if the document at the given position can not be read completely.
@@ -286,7 +286,7 @@ class ReadablePartition extends events.EventEmitter {
             return false;
         }
 
-        assert((position % DOCUMENT_ALIGNMENT) === 0, `Invalid read position. Needs to be a multiple of ${DOCUMENT_ALIGNMENT}.`);
+        assert((position % DOCUMENT_ALIGNMENT) === 0, `Invalid read position ${position}. Needs to be a multiple of ${DOCUMENT_ALIGNMENT}.`);
 
         const reader = this.prepareReadBuffer(position);
         if (reader.length < size + DOCUMENT_HEADER_SIZE) {

--- a/src/util.js
+++ b/src/util.js
@@ -27,6 +27,17 @@ function assert(condition, message, ErrorType = Error) {
 }
 
 /**
+ * Return the amount required to align value to the given alignment.
+ * It calculates the difference of the alignment and the modulo of value by alignment.
+ * @param {number} value
+ * @param {number} alignment
+ * @returns {number}
+ */
+function alignTo(value, alignment) {
+    return (alignment - (value % alignment)) % alignment;
+}
+
+/**
  * @param {string} secret The secret to use for calculating further HMACs
  * @returns {function(string)} A function that calculates the HMAC for a given string
  */
@@ -177,5 +188,6 @@ module.exports = {
     matches,
     buildMetadataForMatcher,
     buildMatcherFromMetadata,
-    buildMetadataHeader
+    buildMetadataHeader,
+    alignTo
 };

--- a/test/Partition.spec.js
+++ b/test/Partition.spec.js
@@ -184,6 +184,19 @@ describe('Partition', function() {
             expect(i).to.be(0);
         });
 
+        it('reads all documents in backwards write order from arbitary position', function() {
+            partition.open();
+            fillPartition(50, i => 'foo-' + i.toString());
+            partition.close();
+            partition.open();
+            let i = 50;
+            for (let data of partition.readAllBackwards(-9)) {
+                expect(data).to.be('foo-' + i.toString());
+                i--;
+            }
+            expect(i).to.be(0);
+        });
+
     });
 
     describe('readFrom', function() {

--- a/test/Partition.spec.js
+++ b/test/Partition.spec.js
@@ -156,6 +156,36 @@ describe('Partition', function() {
 
     });
 
+    describe('readAll', function() {
+
+        it('reads all documents in write order', function() {
+            partition.open();
+            fillPartition(50, i => 'foo-' + i.toString());
+            partition.close();
+            partition.open();
+            let i = 1;
+            for (let data of partition.readAll()) {
+                expect(data).to.be('foo-' + i.toString());
+                i++;
+            }
+            expect(i).to.be(51);
+        });
+
+        it('reads all documents in backwards write order', function() {
+            partition.open();
+            fillPartition(50, i => 'foo-' + i.toString());
+            partition.close();
+            partition.open();
+            let i = 50;
+            for (let data of partition.readAllBackwards()) {
+                expect(data).to.be('foo-' + i.toString());
+                i--;
+            }
+            expect(i).to.be(0);
+        });
+
+    });
+
     describe('readFrom', function() {
 
         it('returns false when partition is not open', function() {


### PR DESCRIPTION
Adds the method `readAllBackwards()` which scans the partition in reverse order without needing an index.