### PR TITLE
Truncate torn writes

### DIFF
--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -12,6 +12,8 @@ const DOCUMENT_FOOTER_SIZE = 4 /* additional data size footer */ + DOCUMENT_SEPA
 // node-event-store partition V03
 const HEADER_MAGIC = "nesprt03";
 
+const NES_EPOCH = new Date('2020-01-01T00:00:00');
+
 class CorruptFileError extends Error {}
 class InvalidDataSizeError extends Error {}
 
@@ -150,6 +152,7 @@ class ReadablePartition extends events.EventEmitter {
         const metadata = metadataBuffer.toString('utf8').trim();
         try {
             this.metadata = JSON.parse(metadata);
+            this.metadata.epoch = this.metadata.epoch /* istanbul ignore next */|| NES_EPOCH.getTime();
         } catch (e) {
             throw new Error('Invalid metadata.');
         }

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -181,6 +181,7 @@ class WritablePartition extends ReadablePartition {
         if (time64 === null) {
             time64 = this.clock.time();
         }
+        /* istanbul ignore if */
         if (time64 < 0) {
             throw new Error('Time may not be negative!');
         }

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -39,8 +39,8 @@ class WritablePartition extends ReadablePartition {
             },
             clock: Clock
         };
-        config = Object.assign(defaults, config);
         config.metadata = Object.assign(defaults.metadata, config.metadata);
+        config = Object.assign(defaults, config);
         super(name, config);
         if (!fs.existsSync(this.dataDirectory)) {
             mkdirpSync(this.dataDirectory);
@@ -318,6 +318,7 @@ class WritablePartition extends ReadablePartition {
         if (after > this.size) {
             return;
         }
+        this.open();
         after = Math.max(0, after);
         this.flush();
 

--- a/test/Partition.spec.js
+++ b/test/Partition.spec.js
@@ -70,6 +70,13 @@ describe('Partition', function() {
         expect(() => partition.open()).to.throwError();
     });
 
+    it('can open an existing empty file', function() {
+        let fd = fs.openSync('test/data/.part', 'w');
+        fs.closeSync(fd);
+
+        expect(partition.open()).to.be(true);
+    });
+
     it('throws when mismatching header version', function() {
         let fd = fs.openSync('test/data/.part', 'w');
         fs.writeSync(fd, 'nesprt00');
@@ -372,6 +379,15 @@ describe('Partition', function() {
             partition.close();
             partition.open();
             expect(partition.size).to.be(lastposition);
+        });
+
+        it('can not read a truncated document', function() {
+            partition.open();
+            let lastposition = fillPartition(10);
+            expect(partition.readFrom(0)).to.not.be(false);
+            expect(partition.readFrom(lastposition)).to.not.be(false);
+            partition.truncate(lastposition);
+            expect(partition.readFrom(lastposition)).to.be(false);
         });
 
         it('correctly truncates after unflushed writes', function() {


### PR DESCRIPTION
This change allows truncating documents that have been torn and are hence unfinished writes. Those unfinished documents will be stored in the deletion log.

Related to #31