### PR TITLE
Automatically repair torn writes on opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,18 @@ leads to every single document being flushed directly.
 
 #### Consistency
 
-Since the storage is append-only, consistency is automatically guaranteed.
+Since the storage is append-only, consistency is automatically guaranteed for all successful writes. Writes that fail in
+the middle, e.g. because the machine crashes before the full write buffer is flushed, will lead to a torn write. This is
+a partial invalid write. To recover from such a state, the storage will detect torn writes and truncate them when an existing
+lock is reclaimed. This can be done by instantiating the store with the following option:
+
+```javascript
+const eventstore = new EventStore('my-event-store', { storageConfig: { lock: EventStore.LOCK_RECLAIM } });
+```
+
+Note that this option will effectively bypass the lock that prevents multiple instances from being created, so you should
+not use this carelessly. Having multiple instances write to the same files will lead to inconsistent data that can not be
+easily recovered from.
 
 #### Isolation
 

--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -1,8 +1,7 @@
 const stream = require('stream');
 const fs = require('fs');
 const path = require('path');
-const mkdirpSync = require('mkdirp').sync;
-const { assert } = require('./util');
+const { assert, ensureDirectory } = require('./util');
 
 const Storage = require('./Storage/ReadableStorage');
 const MAX_CATCHUP_BATCH = 10;
@@ -59,9 +58,7 @@ class Consumer extends stream.Readable {
         this.indexName = indexName;
         const consumerDirectory = path.join(this.storage.indexDirectory, 'consumers');
         this.fileName = path.join(consumerDirectory, this.storage.storageFile + '.' + indexName + '.' + identifier);
-        if (!fs.existsSync(consumerDirectory)) {
-            mkdirpSync(consumerDirectory);
-        } else {
+        if (ensureDirectory(consumerDirectory)) {
             this.cleanUpFailedWrites();
         }
     }

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -398,3 +398,5 @@ class EventStore extends events.EventEmitter {
 module.exports = EventStore;
 module.exports.ExpectedVersion = ExpectedVersion;
 module.exports.OptimisticConcurrencyError = OptimisticConcurrencyError;
+module.exports.LOCK_THROW = Storage.LOCK_THROW;
+module.exports.LOCK_RECLAIM = Storage.LOCK_RECLAIM;

--- a/src/Index/WritableIndex.js
+++ b/src/Index/WritableIndex.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
-const mkdirpSync = require('mkdirp').sync;
 const ReadableIndex = require('./ReadableIndex');
-const { assertEqual, buildMetadataHeader } = require('../util');
+const { assertEqual, buildMetadataHeader, ensureDirectory } = require('../util');
 
 /**
  * An index is a simple append-only file that stores an ordered list of entry elements pointing to the actual file position
@@ -45,9 +44,7 @@ class WritableIndex extends ReadableIndex {
      */
     initialize(options) {
         super.initialize(options);
-        if (!fs.existsSync(options.dataDirectory)) {
-            mkdirpSync(options.dataDirectory);
-        }
+        ensureDirectory(options.dataDirectory);
 
         this.fileMode = 'a+';
         this.writeBuffer = Buffer.allocUnsafe(options.writeBufferSize >>> 0); // jshint ignore:line

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -363,7 +363,7 @@ class ReadablePartition extends events.EventEmitter {
             }
             position -= this.readBufferLength;
         } while (position > 0);
-        return position;
+        return Math.max(0, position);
     }
 
     /**

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -124,6 +124,21 @@ class ReadablePartition extends events.EventEmitter {
     }
 
     /**
+     * @returns {number} -1 if the partition is ok and the sequence number of the broken document if a torn write was detected.
+     */
+    checkTornWrite() {
+        const reader = this.prepareReadBufferBackwards(this.size);
+        const separator = reader.buffer.toString('ascii', reader.cursor - DOCUMENT_SEPARATOR.length, reader.cursor);
+        if (separator !== DOCUMENT_SEPARATOR) {
+            const position = this.findDocumentPositionBefore(this.size);
+            const reader = this.prepareReadBuffer(position);
+            const { sequenceNumber } = this.readDocumentHeader(reader.buffer, reader.cursor, position);
+            return sequenceNumber;
+        }
+        return -1;
+    }
+
+    /**
      * Read the partition metadata from the file.
      *
      * @private

--- a/src/Partition/WritablePartition.js
+++ b/src/Partition/WritablePartition.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
-const mkdirpSync = require('mkdirp').sync;
 const ReadablePartition = require('./ReadablePartition');
-const { assert, buildMetadataHeader, alignTo } = require('../util');
+const { assert, buildMetadataHeader, alignTo, ensureDirectory } = require('../util');
 const Clock = require('../Clock');
 
 const DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
@@ -40,9 +39,7 @@ class WritablePartition extends ReadablePartition {
         config.metadata = Object.assign(defaults.metadata, config.metadata);
         config = Object.assign(defaults, config);
         super(name, config);
-        if (!fs.existsSync(this.dataDirectory)) {
-            mkdirpSync(this.dataDirectory);
-        }
+        ensureDirectory(this.dataDirectory);
         this.fileMode = 'a+';
         this.writeBufferSize = config.writeBufferSize >>> 0; // jshint ignore:line
         this.maxWriteBufferDocuments = config.maxWriteBufferDocuments >>> 0; // jshint ignore:line

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -138,6 +138,7 @@ class ReadableStorage extends events.EventEmitter {
         for (let file of files) {
             if (file.substr(-6) === '.index') continue;
             if (file.substr(-7) === '.branch') continue;
+            if (file.substr(-5) === '.lock') continue;
             if (file.substr(0, this.storageFile.length) !== this.storageFile) continue;
 
             const partition = this.createPartition(file, this.partitionConfig);

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -86,7 +86,7 @@ class WritableStorage extends ReadableStorage {
             partition.open();
             const tornSequenceNumber = partition.checkTornWrite();
             if (tornSequenceNumber >= 0) {
-                lastValidSequenceNumber = Math.min(lastValidSequenceNumber, tornSequenceNumber - 1);
+                lastValidSequenceNumber = Math.min(lastValidSequenceNumber, tornSequenceNumber);
             }
         });
         if (lastValidSequenceNumber < Number.MAX_SAFE_INTEGER) {

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -125,7 +125,7 @@ class WritableStorage extends ReadableStorage {
      * Current implementation just deletes a lock file that is named like the storage.
      */
     unlock() {
-        if (fs.existsSync(this.lockFile)) {
+        if (!this.locked && fs.existsSync(this.lockFile)) {
             this.checkTornWrites();
         }
         fs.rmdirSync(this.lockFile);

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -72,7 +72,6 @@ class WritableStorage extends ReadableStorage {
         if (!this.lock()) {
             return true;
         }
-        this.checkTornWrites();
         return super.open();
     }
 
@@ -82,7 +81,6 @@ class WritableStorage extends ReadableStorage {
      * torn write in another partition.
      */
     checkTornWrites() {
-        // TODO: Only do this if a potential failed write is detected (e.g. a tx-marker exists)
         let lastValidSequenceNumber = Number.MAX_SAFE_INTEGER;
         this.forEachPartition(partition => {
             partition.open();
@@ -127,6 +125,9 @@ class WritableStorage extends ReadableStorage {
      * Current implementation just deletes a lock file that is named like the storage.
      */
     unlock() {
+        if (fs.existsSync(this.lockFile)) {
+            this.checkTornWrites();
+        }
         fs.rmdirSync(this.lockFile);
         this.locked = false;
     }

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -1,10 +1,9 @@
 const fs = require('fs');
-const mkdirpSync = require('mkdirp').sync;
 const path = require('path');
 const WritablePartition = require('../Partition/WritablePartition');
 const WritableIndex = require('../Index/WritableIndex');
 const ReadableStorage = require('./ReadableStorage');
-const { assert, matches, buildMetadataForMatcher, buildMatcherFromMetadata } = require('../util');
+const { assert, matches, buildMetadataForMatcher, buildMatcherFromMetadata, ensureDirectory } = require('../util');
 
 const DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
 
@@ -57,12 +56,7 @@ class WritableStorage extends ReadableStorage {
         };
         config = Object.assign(defaults, config);
         config.indexOptions = Object.assign({ syncOnFlush: config.syncOnFlush }, config.indexOptions);
-        if (!fs.existsSync(config.dataDirectory)) {
-            try {
-                mkdirpSync(config.dataDirectory);
-            } catch (e) {
-            }
-        }
+        ensureDirectory(config.dataDirectory);
         super(storageName, config);
 
         this.lockFile = path.resolve(this.dataDirectory, this.storageFile + '.lock');

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -88,11 +88,11 @@ class WritableStorage extends ReadableStorage {
             if (tornSequenceNumber >= 0) {
                 lastValidSequenceNumber = Math.min(lastValidSequenceNumber, tornSequenceNumber - 1);
             }
-            partition.close();
         });
         if (lastValidSequenceNumber < Number.MAX_SAFE_INTEGER) {
             this.truncate(lastValidSequenceNumber);
         }
+        this.forEachPartition(partition => partition.close());
     }
 
     /**

--- a/src/util.js
+++ b/src/util.js
@@ -195,10 +195,6 @@ function ensureDirectory(dirName) {
         try {
             mkdirpSync(dirName);
         } catch (e) {
-            if (e.code !== 'EEXIST') {
-                throw e;
-            }
-            return true;
         }
         return false;
     }

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,6 @@
 const crypto = require('crypto');
+const fs = require('fs');
+const mkdirpSync = require('mkdirp').sync;
 
 /**
  * Assert that actual and expected match or throw an Error with the given message appended by information about expected and actual value.
@@ -183,6 +185,27 @@ function wrapAndCheck(index, length) {
     return index;
 }
 
+/**
+ * Ensure that the given directory exists.
+ * @param {string} dirName
+ * @return {boolean} true if the directory existed already
+ */
+function ensureDirectory(dirName) {
+    if (!fs.existsSync(dirName)) {
+        try {
+            mkdirpSync(dirName);
+        } catch (e) {
+            if (e.code !== 'EEXIST') {
+                throw e;
+            }
+            return true;
+        }
+        return false;
+    }
+    return true;
+}
+
+
 module.exports = {
     assert,
     assertEqual,
@@ -193,5 +216,6 @@ module.exports = {
     buildMetadataForMatcher,
     buildMatcherFromMetadata,
     buildMetadataHeader,
-    alignTo
+    alignTo,
+    ensureDirectory
 };


### PR DESCRIPTION
This change checks the storage for torn writes when force unlocking and truncates all partitions (and indexes) to the last valid write. After a crash, this can be done by doing the following (once):
```javascript
const eventstore = new EventStore('my-event-store', { storageConfig: { lock: EventStore.LOCK_RECLAIM } });
```

Related to #31 and #107