### PR TITLE
Change stream version range to 1-based

### DIFF
--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -265,11 +265,11 @@ class EventStore extends events.EventEmitter {
      *
      * @api
      * @param {string} streamName The name of the stream to get.
-     * @param {number} [minRevision] The minimum revision to include in the events (inclusive).
-     * @param {number} [maxRevision] The maximum revision to include in the events (inclusive).
+     * @param {number} [minRevision] The 1-based minimum revision to include in the events (inclusive).
+     * @param {number} [maxRevision] The 1-based maximum revision to include in the events (inclusive).
      * @returns {EventStream|boolean} The event stream or false if a stream with the name doesn't exist.
      */
-    getEventStream(streamName, minRevision = 0, maxRevision = -1) {
+    getEventStream(streamName, minRevision = 1, maxRevision = -1) {
         if (!(streamName in this.streams)) {
             return false;
         }
@@ -281,11 +281,11 @@ class EventStore extends events.EventEmitter {
      * This is the same as `getEventStream('_all', ...)`.
      *
      * @api
-     * @param {number} [minRevision] The minimum revision to include in the events (inclusive).
-     * @param {number} [maxRevision] The maximum revision to include in the events (inclusive).
+     * @param {number} [minRevision] The 1-based minimum revision to include in the events (inclusive).
+     * @param {number} [maxRevision] The 1-based maximum revision to include in the events (inclusive).
      * @returns {EventStream} The event stream.
      */
-    getAllEvents(minRevision = 0, maxRevision = -1) {
+    getAllEvents(minRevision = 1, maxRevision = -1) {
         return this.getEventStream('_all', minRevision, maxRevision);
     }
 
@@ -294,12 +294,12 @@ class EventStore extends events.EventEmitter {
      *
      * @param {string} streamName The (transient) name of the joined stream.
      * @param {Array<string>} streamNames An array of the stream names to join.
-     * @param {number} [minRevision] The minimum revision to include in the events (inclusive).
-     * @param {number} [maxRevision] The maximum revision to include in the events (inclusive).
+     * @param {number} [minRevision] The 1-based minimum revision to include in the events (inclusive).
+     * @param {number} [maxRevision] The 1-based maximum revision to include in the events (inclusive).
      * @returns {EventStream} The joined event stream.
      * @throws {Error} if any of the streams doesn't exist.
      */
-    fromStreams(streamName, streamNames, minRevision = 0, maxRevision = -1) {
+    fromStreams(streamName, streamNames, minRevision = 1, maxRevision = -1) {
         assert(streamNames instanceof Array, 'Must specify an array of stream names.');
 
         for (let stream of streamNames) {
@@ -318,12 +318,12 @@ class EventStore extends events.EventEmitter {
      *
      * @api
      * @param {string} categoryName The name of the category to get a stream for. A category is a stream name prefix.
-     * @param {number} [minRevision] The minimum revision to include in the events (inclusive).
-     * @param {number} [maxRevision] The maximum revision to include in the events (inclusive).
+     * @param {number} [minRevision] The 1-based minimum revision to include in the events (inclusive).
+     * @param {number} [maxRevision] The 1-based maximum revision to include in the events (inclusive).
      * @returns {EventStream} The joined event stream for all streams of the given category.
      * @throws {Error} If no stream for this category exists.
      */
-    getEventStreamForCategory(categoryName, minRevision = 0, maxRevision = -1) {
+    getEventStreamForCategory(categoryName, minRevision = 1, maxRevision = -1) {
         if (categoryName in this.streams) {
             return this.getEventStream(categoryName, minRevision, maxRevision);
         }

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -2,19 +2,6 @@ const stream = require('stream');
 const { assert } = require('./util');
 
 /**
- * Adjusts a revision number from the EventStore/EventStream interface range into the underlying storage item number.
- *
- * @param {number} rev A zero-based revision number, or a negative number to denote a "from the end" position
- * @returns {number} A one-based storage item number
- */
-function adjustedRevision(rev) {
-    if (rev >= 0) {
-        return rev + 1;
-    }
-    return rev;
-}
-
-/**
  * Return the lower absolute version given a version and a maxVersion constraint.
  * @param {number} version
  * @param {number} maxVersion
@@ -36,7 +23,7 @@ class EventStream extends stream.Readable {
      * @param {number} [minRevision] The minimum revision to include in the events (inclusive).
      * @param {number} [maxRevision] The maximum revision to include in the events (inclusive).
      */
-    constructor(name, eventStore, minRevision = 0, maxRevision = -1) {
+    constructor(name, eventStore, minRevision = 1, maxRevision = -1) {
         super({ objectMode: true });
         assert(typeof name === 'string' && name !== '', 'Need to specify a stream name.');
         assert(typeof eventStore === 'object' && eventStore !== null, `Need to provide EventStore instance to create EventStream ${name}.`);
@@ -45,8 +32,6 @@ class EventStream extends stream.Readable {
         if (eventStore.streams[name]) {
             const streamIndex = eventStore.streams[name].index;
             this.version = minVersion(streamIndex.length, maxRevision);
-            minRevision = adjustedRevision(minRevision);
-            maxRevision = adjustedRevision(maxRevision);
             this.iterator = eventStore.storage.readRange(minRevision, maxRevision, streamIndex);
         } else {
             this.version = -1;

--- a/src/Index/ReadableIndex.js
+++ b/src/Index/ReadableIndex.js
@@ -388,6 +388,9 @@ class ReadableIndex extends events.EventEmitter {
      * @returns {number} The last index entry position that is lower than or equal to the `number`. Returns 0 if no index matches.
      */
     find(number, min = false) {
+        if (this.length < 1) {
+            return 0;
+        }
         // We only need to search until the searched number because entry.number is always >= position
         const [low, high] = binarySearch(number, Math.min(this.length, number), index => this.get(index).number);
         return min ? low : high;

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -33,7 +33,7 @@ class JoinEventStream extends EventStream {
             const streamIndex = eventStore.streams[streamName].index;
             const from = streamIndex.find(minRevision, !this.reverse);
             const until = streamIndex.find(maxRevision, this.reverse);
-            return eventStore.storage.readRange(from || 1, until, streamIndex);
+            return eventStore.storage.readRange(from, until, streamIndex);
         });
     }
 

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -375,6 +375,30 @@ describe('EventStore', function() {
             }
         });
 
+        it('behaves as expected with ranges', function() {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+
+            for (let i=1; i<=20; i++) {
+                eventstore.commit('foo-bar', [{key: i}]);
+            }
+
+            const last10 = eventstore.getEventStream('foo-bar', -10, -1);
+            expect(last10.events.length).to.be(10);
+            let i = 11;
+            for (let event of last10.events) {
+                expect(event).to.eql({ key: i++ });
+            }
+
+            const first10 = eventstore.getEventStream('foo-bar', 1, 10);
+            expect(first10.events.length).to.be(10);
+            i = 1;
+            for (let event of first10.events) {
+                expect(event).to.eql({ key: i++ });
+            }
+        });
+
         it('can open streams created in writer', function(done) {
             eventstore = new EventStore({
                 storageDirectory

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -82,8 +82,8 @@ describe('EventStream', function() {
         });
     });
 
-    it('adjusts revisions to 1-based index', function(){
-        stream = new EventStream('foo', mockEventStore, 0, 1);
+    it('accepts revisions as 1-based index', function(){
+        stream = new EventStream('foo', mockEventStore, 1, 2);
         const events = stream.events;
 
         expect(mockEventStore.storage.from).to.be(1);

--- a/test/JoinEventStream.spec.js
+++ b/test/JoinEventStream.spec.js
@@ -75,7 +75,7 @@ describe('JoinEventStream', function() {
     });
 
     it('can limit events fetched with min and max revision', function(){
-        stream = new JoinEventStream('foo-bar', ['foo', 'bar'], eventstore, 0, 1);
+        stream = new JoinEventStream('foo-bar', ['foo', 'bar'], eventstore, 1, 2);
         const fetchedEvents = stream.events;
 
         expect(fetchedEvents.length).to.be(2);


### PR DESCRIPTION
This changes the `getEventStream*()`/`fromStreams()` revision range API to be 1-based instead of the previous 0-based approach that was confusing. The inner layers (index and storage) already were 1-based and made a translation necessary. Also the result of `getEventStream('foo', 1, 10)` would return events no. 2 until no. 11 which was totally unintuitive.
With this the version ranges are symmetric around around for "from the start" and "from the end" usage.

**Note:** This change is breaking if you used any of the above methods and specified a positive version range. In that case you need to increment the versions by one and prevent any use of `0` as a valid version. 

Resolves #166 