### PR TITLE
Add natural language API to EventStream version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,19 +194,30 @@ Apart from that, you can also specify the exact version range you want to iterat
 possible to iterate the stream in reverse, by specifying a lower `max` than `min` revision.
 
 ```javascript
-const stream0 = eventstore.getEventStream('my-stream', 0, -1); // all events from the start (#0) up to the last (-1 equals the last version)
-const stream1 = eventstore.getEventStream('my-stream', 0, 50); // all events from the start (#0) up to event #50, hence 51 events in total
-const stream2 = eventstore.getEventStream('my-stream', 10, -11); // the events starting from #10 up to the 10th last event
-const stream3 = eventstore.getEventStream('my-stream', -11, -1); // get the last ten events starting from the earliest
-const stream4 = eventstore.getEventStream('my-stream', -1, -11); // get the last ten events starting from the last in reverse order
+const stream0 = eventstore.getEventStream('my-stream', 1, -1); // all events from the start (#1) up to the last (-1 equals the last version)
+const stream1 = eventstore.getEventStream('my-stream', 1, 50); // all events from the start (#1) up to event #50, hence 50 events in total
+const stream2 = eventstore.getEventStream('my-stream', 10, -10); // the events starting from #10 up to the 10th last event
+const stream3 = eventstore.getEventStream('my-stream', -10, -1); // get the last ten events starting from the earliest
+const stream4 = eventstore.getEventStream('my-stream', -1, -10); // get the last ten events starting from the last in reverse order
 
 for (let event of stream{x}) {
    //...
 }
 ```
 
+Since version 0.9 the EventStream API also allows specifying the version range with a natural language like this:
+```javascript
+const allBackwards  = eventstore.getEventStream('my-stream').backwards();
+const first10       = eventstore.getEventStream('my-stream').first(10);
+const last10        = eventstore.getEventStream('my-stream').last(10);
+const after15       = eventstore.getEventStream('my-stream').from(16).toEnd();
+const before10      = eventstore.getEventStream('my-stream').fromStart().until(10).backwards();
+const middle10      = eventstore.getEventStream('my-stream').from(5).following(10);
+const middle10alt   = eventstore.getEventStream('my-stream').from(14).previous(10).forwards();
+```
+
 **Note**
-> If a new event is appended right after the `getEventStream()` call, but before iterating, this event will **not** be included in the iteration.
+> If a new event is appended right after the `getEventStream()` (including range selection methods) call, but before iterating, this event will **not** be included in the iteration.
 > This is due to the revision boundary being fixed at the time of getting the stream reference. In some cases this might be unwanted, but those cases are
 > probably better covered by [consumers](#consumers).
 

--- a/README.md
+++ b/README.md
@@ -208,12 +208,21 @@ for (let event of stream{x}) {
 Since version 0.9 the EventStream API also allows specifying the version range with a natural language like this:
 ```javascript
 const allBackwards  = eventstore.getEventStream('my-stream').backwards();
+                    // OR eventstore.getEventStream('my-stream').fromEnd().toStart();
 const first10       = eventstore.getEventStream('my-stream').first(10);
+                    // OR eventstore.getEventStream('my-stream').fromStart().forwards(10);
 const last10        = eventstore.getEventStream('my-stream').last(10);
+                    // OR eventstore.getEventStream('my-stream').from(-10).forwards(10);
+const last10reverse = eventstore.getEventStream('my-stream').last(10).backwards();
+                    // OR eventstore.getEventStream('my-stream').fromEnd().backwards(10);
 const after15       = eventstore.getEventStream('my-stream').from(16).toEnd();
-const before10      = eventstore.getEventStream('my-stream').fromStart().until(10).backwards();
-const middle10      = eventstore.getEventStream('my-stream').from(5).following(10);
-const middle10alt   = eventstore.getEventStream('my-stream').from(14).previous(10).forwards();
+const before10      = eventstore.getEventStream('my-stream').from(10).toStart();
+                    // OR eventstore.getEventStream('my-stream').fromStart().until(10).backwards();
+const middle10      = eventstore.getEventStream('my-stream').from(5).forwards(10);
+                    // OR eventstore.getEventStream('my-stream').from(5).following(10);
+                    // OR eventstore.getEventStream('my-stream').from(14).previous(10).forwards();
+const from9to5      = eventstore.getEventStream('my-stream').from(9).until(5);
+                    // OR eventstore.getEventStream('my-stream').from(5).until(9).backwards();
 ```
 
 **Note**

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -2,6 +2,17 @@ const EventStream = require('./EventStream');
 const { wrapAndCheck } = require('./util');
 
 /**
+ * Calculate the actual version number from a possibly relative (negative) version number.
+ *
+ * @param {number} version The version to normalize.
+ * @param {number} length The maximum version number
+ * @returns {number} The absolute version number.
+ */
+function normalizeVersion(version, length) {
+    return version < 0 ? version + length + 1 : version;
+}
+
+/**
  * An event stream is a simple wrapper around an iterator over storage documents.
  * It implements a node readable stream interface.
  */
@@ -19,22 +30,24 @@ class JoinEventStream extends EventStream {
         if (!(streams instanceof Array) || streams.length === 0) {
             throw new Error(`Invalid list of streams supplied to JoinStream ${name}.`);
         }
-        this._next = new Array(streams.length).fill(undefined);
 
+        this.streamIndex = eventStore.storage.index;
         // Translate revisions to index numbers (1-based) and wrap around negatives
-        minRevision = wrapAndCheck(minRevision, eventStore.length);
-        maxRevision = wrapAndCheck(maxRevision, eventStore.length);
-
-        this.reverse = minRevision > maxRevision;
-        this.iterator = streams.map(streamName => {
-            if (!eventStore.streams[streamName]) {
-                return { next() { return { done: true }; } };
-            }
-            const streamIndex = eventStore.streams[streamName].index;
-            const from = streamIndex.find(minRevision, !this.reverse);
-            const until = streamIndex.find(maxRevision, this.reverse);
-            return eventStore.storage.readRange(from, until, streamIndex);
-        });
+        this.minRevision = normalizeVersion(minRevision, eventStore.length);
+        this.maxRevision = normalizeVersion(maxRevision, eventStore.length);
+        this.fetch = function() {
+            this._next = new Array(streams.length).fill(undefined);
+            return streams.map(streamName => {
+                if (!eventStore.streams[streamName]) {
+                    return { next() { return { done: true }; } };
+                }
+                const streamIndex = eventStore.streams[streamName].index;
+                const from = streamIndex.find(this.minRevision, this.minRevision <= this.maxRevision);
+                const until = streamIndex.find(this.maxRevision, this.minRevision > this.maxRevision);
+                return eventStore.storage.readRange(from, until, streamIndex);
+            });
+        }
+        this.iterator = null;
     }
 
     /**
@@ -51,10 +64,10 @@ class JoinEventStream extends EventStream {
      * @private
      * @param {number} first
      * @param {number} second
-     * @returns {boolean} If the first item follows after the second in the given read order determined by this.reverse flag.
+     * @returns {boolean} If the first item follows after the second in the given read order determined by this.minRevision and this.maxRevision.
      */
     follows(first, second) {
-        return (this.reverse ? first < second : first > second);
+        return (this.minRevision > this.maxRevision ? first < second : first > second);
     }
 
     /**
@@ -62,6 +75,9 @@ class JoinEventStream extends EventStream {
      * @returns {object|boolean} The next event or false if no more events in the stream.
      */
     next() {
+        if (!this.iterator) {
+            this.iterator = this.fetch();
+        }
         let nextIndex = -1;
         this._next.forEach((value, index) => {
             if (typeof value === 'undefined') {

--- a/src/util.js
+++ b/src/util.js
@@ -169,7 +169,7 @@ function binarySearch(number, length, get) {
 /**
  * @param {number} index The 1-based index position to wrap around if < 0 and check against the bounds.
  * @param {number} length The length of the index and upper bound.
- * @returns {number} The wrapped index or -1 if index out of bounds.
+ * @returns {number} The wrapped index position or -1 if index out of bounds.
  */
 function wrapAndCheck(index, length) {
     if (typeof index !== 'number') {

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -410,11 +410,11 @@ describe('EventStore', function() {
             }
 
             const allBackwards  = eventstore.getEventStream('foo-bar').backwards();
-            const first10       = eventstore.getEventStream('foo-bar').first(10);
-            const last10        = eventstore.getEventStream('foo-bar').last(10);
+            const first10       = eventstore.getEventStream('foo-bar').first(10); // fromStart().forwards(10)
+            const last10        = eventstore.getEventStream('foo-bar').last(10); // from(-10).forwards(), fromEnd().previous(10).forwards()
             const after15       = eventstore.getEventStream('foo-bar').from(16).toEnd();
-            const before10      = eventstore.getEventStream('foo-bar').fromStart().until(10).backwards();
-            const middle10      = eventstore.getEventStream('foo-bar').from(5).following(10);
+            const before10      = eventstore.getEventStream('foo-bar').fromStart().until(10).backwards(); // from(10).backwards(10)
+            const middle10      = eventstore.getEventStream('foo-bar').from(5).forwards(10);
             const middle10alt   = eventstore.getEventStream('foo-bar').from(14).previous(10).forwards();
             // Tests that `forwards()` and `backwards()` are noops on already like ordered ranges
             const allForwards   = eventstore.getEventStream('foo-bar').fromStart().toEnd().forwards();

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -416,6 +416,7 @@ describe('EventStore', function() {
             const before10      = eventstore.getEventStream('foo-bar').fromStart().until(10).backwards(); // from(10).backwards(10)
             const middle10      = eventstore.getEventStream('foo-bar').from(5).forwards(10);
             const middle10alt   = eventstore.getEventStream('foo-bar').from(14).previous(10).forwards();
+            const last10backward= eventstore.getEventStream('foo-bar').fromEnd().backwards(10);
             // Tests that `forwards()` and `backwards()` are noops on already like ordered ranges
             const allForwards   = eventstore.getEventStream('foo-bar').fromStart().toEnd().forwards();
             const allBackwards2 = eventstore.getEventStream('foo-bar').fromEnd().toStart().backwards();
@@ -447,6 +448,10 @@ describe('EventStore', function() {
             expect(middle10alt.events.length).to.be(10);
             expect(middle10alt.events[0].key).to.be(5);
             expect(middle10alt.events[9].key).to.be(14);
+
+            expect(last10backward.events.length).to.be(10);
+            expect(last10backward.events[0].key).to.be(20);
+            expect(last10backward.events[9].key).to.be(11);
 
             expect(allForwards.events.length).to.be(20);
             expect(allForwards.events[0].key).to.be(1);

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -400,6 +400,52 @@ describe('EventStore', function() {
             }
         });
 
+        it('supports natural language range api', function(){
+            eventstore = new EventStore({
+                storageDirectory
+            });
+
+            for (let i=1; i<=20; i++) {
+                eventstore.commit('foo-bar', [{key: i}]);
+            }
+
+            const allBackwards  = eventstore.getEventStream('foo-bar').backwards();
+            const first10       = eventstore.getEventStream('foo-bar').first(10);
+            const last10        = eventstore.getEventStream('foo-bar').last(10);
+            const after15       = eventstore.getEventStream('foo-bar').from(16).toEnd();
+            const before10      = eventstore.getEventStream('foo-bar').fromStart().until(10).backwards();
+            const middle10      = eventstore.getEventStream('foo-bar').from(5).following(10);
+            const middle10alt   = eventstore.getEventStream('foo-bar').from(14).previous(10).forwards();
+
+            expect(allBackwards.events.length).to.be(20);
+            expect(allBackwards.events[0].key).to.be(20);
+            expect(allBackwards.events[19].key).to.be(1);
+
+            expect(first10.events.length).to.be(10);
+            expect(first10.events[0].key).to.be(1);
+            expect(first10.events[9].key).to.be(10);
+
+            expect(last10.events.length).to.be(10);
+            expect(last10.events[0].key).to.be(11);
+            expect(last10.events[9].key).to.be(20);
+
+            expect(after15.events.length).to.be(5);
+            expect(after15.events[0].key).to.be(16);
+            expect(after15.events[4].key).to.be(20);
+
+            expect(before10.events.length).to.be(10);
+            expect(before10.events[0].key).to.be(10);
+            expect(before10.events[9].key).to.be(1);
+
+            expect(middle10.events.length).to.be(10);
+            expect(middle10.events[0].key).to.be(5);
+            expect(middle10.events[9].key).to.be(14);
+
+            expect(middle10alt.events.length).to.be(10);
+            expect(middle10alt.events[0].key).to.be(5);
+            expect(middle10alt.events[9].key).to.be(14);
+        });
+
         it('can open streams created in writer', function(done) {
             eventstore = new EventStore({
                 storageDirectory
@@ -504,7 +550,7 @@ describe('EventStore', function() {
                 eventstore.commit(i % 2 ? 'foo' : 'bar', [{key: i}]);
             }
 
-            let reverseStream = eventstore.fromStreams('foo-bar', ['foo', 'bar'],-1, 0);
+            let reverseStream = eventstore.fromStreams('foo-bar', ['foo', 'bar'],-1, 1);
             let i = 20;
             for (let event of reverseStream) {
                 expect(event).to.eql({ key: i-- });

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -416,6 +416,9 @@ describe('EventStore', function() {
             const before10      = eventstore.getEventStream('foo-bar').fromStart().until(10).backwards();
             const middle10      = eventstore.getEventStream('foo-bar').from(5).following(10);
             const middle10alt   = eventstore.getEventStream('foo-bar').from(14).previous(10).forwards();
+            // Tests that `forwards()` and `backwards()` are noops on already like ordered ranges
+            const allForwards   = eventstore.getEventStream('foo-bar').fromStart().toEnd().forwards();
+            const allBackwards2 = eventstore.getEventStream('foo-bar').fromEnd().toStart().backwards();
 
             expect(allBackwards.events.length).to.be(20);
             expect(allBackwards.events[0].key).to.be(20);
@@ -444,6 +447,14 @@ describe('EventStore', function() {
             expect(middle10alt.events.length).to.be(10);
             expect(middle10alt.events[0].key).to.be(5);
             expect(middle10alt.events[9].key).to.be(14);
+
+            expect(allForwards.events.length).to.be(20);
+            expect(allForwards.events[0].key).to.be(1);
+            expect(allForwards.events[19].key).to.be(20);
+
+            expect(allBackwards2.events.length).to.be(20);
+            expect(allBackwards2.events[0].key).to.be(20);
+            expect(allBackwards2.events[19].key).to.be(1);
         });
 
         it('can open streams created in writer', function(done) {

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -99,6 +99,44 @@ describe('EventStream', function() {
         expect(mockEventStore.storage.until).to.be(-1);
     });
 
+    it('allows specifying version range in natural language', function(){
+        stream.fromStart().toEnd();
+        // read all and convert to array
+        let events = stream.events;
+        expect(mockEventStore.storage.from).to.be(1);
+        expect(mockEventStore.storage.until).to.be(events.length);
+
+        stream = new EventStream('foo', mockEventStore).first(2);
+        // read all and convert to array
+        events = stream.events;
+        expect(mockEventStore.storage.from).to.be(1);
+        expect(mockEventStore.storage.until).to.be(2);
+
+        stream = new EventStream('foo', mockEventStore).last(2);
+        // read all and convert to array
+        events = stream.events;
+        expect(mockEventStore.storage.from).to.be(events.length - 1);
+        expect(mockEventStore.storage.until).to.be(events.length);
+
+        stream = new EventStream('foo', mockEventStore).from(2).toEnd();
+        // read all and convert to array
+        events = stream.events;
+        expect(mockEventStore.storage.from).to.be(2);
+        expect(mockEventStore.storage.until).to.be(events.length);
+
+        stream = new EventStream('foo', mockEventStore).fromEnd().toStart();
+        // read all and convert to array
+        events = stream.events;
+        expect(mockEventStore.storage.from).to.be(events.length);
+        expect(mockEventStore.storage.until).to.be(1);
+
+        stream = new EventStream('foo', mockEventStore).fromStart().toEnd().backwards();
+        // read all and convert to array
+        events = stream.events;
+        expect(mockEventStore.storage.from).to.be(events.length);
+        expect(mockEventStore.storage.until).to.be(1);
+    });
+
     it('is empty when stream does not exist', function(){
         stream = new EventStream('bar', mockEventStore);
         expect(stream.events).to.be.eql([]);

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -90,13 +90,13 @@ describe('EventStream', function() {
         expect(mockEventStore.storage.until).to.be(2);
     });
 
-    it('leaves negative revisions untouched', function(){
+    it('adjusts negative revisions to stream length', function(){
         stream = new EventStream('foo', mockEventStore, -1, -1);
         // read all and convert to array
         const events = stream.events;
 
-        expect(mockEventStore.storage.from).to.be(-1);
-        expect(mockEventStore.storage.until).to.be(-1);
+        expect(mockEventStore.storage.from).to.be(events.length);
+        expect(mockEventStore.storage.until).to.be(events.length);
     });
 
     it('allows specifying version range in natural language', function(){

--- a/test/EventStream.spec.js
+++ b/test/EventStream.spec.js
@@ -106,33 +106,23 @@ describe('EventStream', function() {
         expect(mockEventStore.storage.from).to.be(1);
         expect(mockEventStore.storage.until).to.be(events.length);
 
-        stream = new EventStream('foo', mockEventStore).first(2);
-        // read all and convert to array
-        events = stream.events;
+        events = stream.reset().first(2).events;
         expect(mockEventStore.storage.from).to.be(1);
         expect(mockEventStore.storage.until).to.be(2);
 
-        stream = new EventStream('foo', mockEventStore).last(2);
-        // read all and convert to array
-        events = stream.events;
+        events = stream.reset().last(2).events;
         expect(mockEventStore.storage.from).to.be(events.length - 1);
         expect(mockEventStore.storage.until).to.be(events.length);
 
-        stream = new EventStream('foo', mockEventStore).from(2).toEnd();
-        // read all and convert to array
-        events = stream.events;
+        events = stream.reset().from(2).toEnd().events;
         expect(mockEventStore.storage.from).to.be(2);
         expect(mockEventStore.storage.until).to.be(events.length);
 
-        stream = new EventStream('foo', mockEventStore).fromEnd().toStart();
-        // read all and convert to array
-        events = stream.events;
+        events = stream.reset().fromEnd().toStart().events;
         expect(mockEventStore.storage.from).to.be(events.length);
         expect(mockEventStore.storage.until).to.be(1);
 
-        stream = new EventStream('foo', mockEventStore).fromStart().toEnd().backwards();
-        // read all and convert to array
-        events = stream.events;
+        events = stream.reset().fromStart().toEnd().backwards().events;
         expect(mockEventStore.storage.from).to.be(events.length);
         expect(mockEventStore.storage.until).to.be(1);
     });

--- a/test/JoinEventStream.spec.js
+++ b/test/JoinEventStream.spec.js
@@ -92,6 +92,37 @@ describe('JoinEventStream', function() {
         expect(fetchedEvents[1]).to.eql(events[2]);
     });
 
+    it('allows specifying version range in natural language', function(){
+        stream = new JoinEventStream('foo-bar', ['foo', 'bar'], eventstore).fromStart().toEnd();
+
+        let fetchedEvents = stream.events;
+        expect(fetchedEvents.length).to.be(3);
+        expect(fetchedEvents).to.eql(events);
+
+        fetchedEvents = stream.reset().first(2).events;
+        expect(fetchedEvents.length).to.be(2);
+        expect(fetchedEvents[0]).to.eql(events[0]);
+        expect(fetchedEvents[1]).to.eql(events[1]);
+
+        fetchedEvents = stream.reset().last(2).events;
+        expect(fetchedEvents.length).to.be(2);
+        expect(fetchedEvents[0]).to.eql(events[1]);
+        expect(fetchedEvents[1]).to.eql(events[2]);
+
+        fetchedEvents = stream.reset().from(2).toEnd().events;
+        expect(fetchedEvents.length).to.be(2);
+        expect(fetchedEvents[0]).to.eql(events[1]);
+        expect(fetchedEvents[1]).to.eql(events[2]);
+
+        fetchedEvents = stream.reset().fromEnd().toStart().events;
+        expect(fetchedEvents.length).to.be(3);
+        expect(fetchedEvents).to.eql(Array.from(events).reverse());
+
+        fetchedEvents = stream.reset().fromStart().toEnd().backwards().events;
+        expect(fetchedEvents.length).to.be(3);
+        expect(fetchedEvents).to.eql(Array.from(events).reverse());
+    });
+
     it('is empty when stream does not exist', function(){
         stream = new JoinEventStream('foo-bar', ['baz'], eventstore);
         expect(stream.events).to.be.eql([]);


### PR DESCRIPTION
With this an EventStream can be limited in revision range with a natural language API like this:
```javascript
const allBackwards  = eventstore.getEventStream('my-stream').backwards();
                    // OR eventstore.getEventStream('my-stream').fromEnd().toStart();
const first10       = eventstore.getEventStream('my-stream').first(10);
                    // OR eventstore.getEventStream('my-stream').fromStart().forwards(10);
const last10        = eventstore.getEventStream('my-stream').last(10);
                    // OR eventstore.getEventStream('my-stream').from(-10).forwards(10);
const last10reverse = eventstore.getEventStream('my-stream').last(10).backwards();
                    // OR eventstore.getEventStream('my-stream').fromEnd().backwards(10);
const after15       = eventstore.getEventStream('my-stream').from(16).toEnd();
const before10      = eventstore.getEventStream('my-stream').from(10).toStart();
                    // OR eventstore.getEventStream('my-stream').fromStart().until(10).backwards();
const middle10      = eventstore.getEventStream('my-stream').from(5).forwards(10);
                    // OR eventstore.getEventStream('my-stream').from(5).following(10);
                    // OR eventstore.getEventStream('my-stream').from(14).previous(10).forwards();
const from9to5      = eventstore.getEventStream('my-stream').from(9).until(5);
                    // OR eventstore.getEventStream('my-stream').from(5).until(9).backwards();
```
Related to #166