### PR TITLE
Fix EventStore.getConsumer returning Consumer instance

### DIFF
--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -15,24 +15,6 @@ const ExpectedVersion = {
 
 class OptimisticConcurrencyError extends Error {}
 
-class EventUnwrapper extends stream.Transform {
-
-    constructor() {
-        super({ objectMode: true });
-    }
-
-    _transform(data, encoding, callback) {
-        /* istanbul ignore else */
-        if (data.stream && data.payload) {
-            this.push(data.payload);
-        } else {
-            this.push(data);
-        }
-        callback();
-    }
-
-}
-
 /**
  * An event store optimized for working with many streams.
  * An event stream is implemented as an iterator over an index on the storage, therefore indexes need to be lightweight
@@ -392,7 +374,7 @@ class EventStore extends events.EventEmitter {
     getConsumer(streamName, identifier, initialState = {}, since = 0) {
         const consumer = new Consumer(this.storage, 'stream-' + streamName, identifier, initialState, since);
         consumer.streamName = streamName;
-        return consumer.pipe(new EventUnwrapper());
+        return consumer;
     }
 }
 

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -2,6 +2,7 @@ const expect = require('expect.js');
 const fs = require('fs-extra');
 const path = require('path');
 const EventStore = require('../src/EventStore');
+const Consumer = require('../src/Consumer');
 
 const storageDirectory = __dirname + '/data';
 
@@ -638,6 +639,16 @@ describe('EventStore', function() {
 
     describe('getConsumer', function() {
 
+        it('returns a Consumer instance', function() {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+            eventstore.createEventStream('foo-bar', event => event.payload.foo === 'bar');
+
+            const consumer = eventstore.getConsumer('foo-bar', 'consumer2');
+            expect(consumer instanceof Consumer).to.be(true);
+        });
+
         it('returns a consumer for the given stream', function(done) {
             eventstore = new EventStore({
                 storageDirectory
@@ -646,7 +657,7 @@ describe('EventStore', function() {
 
             const consumer = eventstore.getConsumer('foo-bar', 'consumer1');
             consumer.on('data', event => {
-                expect(event.id).to.be(2);
+                expect(event.payload.id).to.be(2);
                 done();
             });
             eventstore.commit('foo', { foo: 'baz', id: 1 });


### PR DESCRIPTION
This change removes the EventUnwrapper transform stream from `EventStore.getConsumer()`, which made the method return a `stream.Transform` instead of an instance of `Consumer`.
This means that the Consumer from an EventStore receives stored event structures, which constist of `{ stream: string, payload: object, metadata: object }`, where `payload` corresponds to the original event that was committed.

Resolves #172