### PR TITLE
Allow to create a Consumer for the _all stream/global index

### DIFF
--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -372,7 +372,7 @@ class EventStore extends events.EventEmitter {
      * @returns {Consumer} A durable consumer for the given stream.
      */
     getConsumer(streamName, identifier, initialState = {}, since = 0) {
-        const consumer = new Consumer(this.storage, 'stream-' + streamName, identifier, initialState, since);
+        const consumer = new Consumer(this.storage, streamName === '_all' ? '_all' : 'stream-' + streamName, identifier, initialState, since);
         consumer.streamName = streamName;
         return consumer;
     }

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -289,6 +289,9 @@ class ReadableStorage extends events.EventEmitter {
      * @throws {Error} if the HMAC for the matcher does not match.
      */
     openIndex(name, matcher) {
+        if (name === '_all') {
+            return this.index;
+        }
         if (name in this.secondaryIndexes) {
             return this.secondaryIndexes[name].index;
         }

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -348,6 +348,7 @@ class WritableStorage extends ReadableStorage {
 
         this.index.truncate(after);
         this.forEachSecondaryIndex(index => {
+            /* istanbul ignore if */
             if (!(index instanceof WritableIndex)) {
                 return;
             }

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -241,6 +241,9 @@ class WritableStorage extends ReadableStorage {
      * @throws {Error} if the index doesn't exist yet and no matcher was specified.
      */
     ensureIndex(name, matcher) {
+        if (name === '_all') {
+            return this.index;
+        }
         if (name in this.secondaryIndexes) {
             return this.secondaryIndexes[name].index;
         }

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -664,6 +664,23 @@ describe('EventStore', function() {
             eventstore.commit('foo', { foo: 'bar', id: 2 });
         });
 
+        it('can return a consumer for the _all stream', function(done) {
+            eventstore = new EventStore({
+                storageDirectory
+            });
+
+            const consumer = eventstore.getConsumer('_all', 'consumer1');
+            expect(consumer instanceof Consumer).to.be(true);
+            let i = 0;
+            consumer.on('data', event => {
+                expect(event.payload.id).to.be(++i);
+                if (i === 2) {
+                    done();
+                }
+            });
+            eventstore.commit('foo', { foo: 'bar', id: 1 });
+            eventstore.commit('bar', { foo: 'baz', id: 2 });
+        });
     });
 
 });

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -410,6 +410,12 @@ describe('Storage', function() {
             expect(fs.existsSync('test/data/storage.foo.index')).to.be(true);
         });
 
+        it('returns global index for `_all`', function() {
+            storage = createStorage();
+            const index = storage.ensureIndex('_all');
+            expect(index).to.be(storage.index);
+        })
+
         it('can be called multiple times', function() {
             storage = createStorage();
             storage.open();


### PR DESCRIPTION
This allows the Consumer to listen to the `_all` stream, which maps to the global index of the underlying storage. Internally, the `storage.openIndex(indexName)` method now also allows specifying `_all` as index name, which will return the global index. This in turn means that the name `_all` is no longer available as a regular index name.