### PR TITLE
Switch Clock to BigInt and fix monotonicity

### DIFF
--- a/src/Clock.js
+++ b/src/Clock.js
@@ -29,7 +29,8 @@ class Clock {
     }
 
     /**
-     * Return the clock accuracy of the given timestamp.
+     * Return the clock accuracy of the given timestamp. This is only useful for calculating a consistent ordering
+     * ala TrueTime for multi-writer scenarios.
      * @param {number} time A timestamp measured by this clock.
      * @returns {number} The amount of µs accuracy this timestamp has.
      */

--- a/src/Clock.js
+++ b/src/Clock.js
@@ -1,6 +1,6 @@
-const TIME_BASE = process.hrtime();
-const DATE_BASE_US = Date.now() * 1000.0 + 999.0; // DATE_BASE_US should match the TIME_BASE with lower resolution, but never be less
-const US_PER_SEC = 1.0e6;
+const TIME_BASE = process.hrtime.bigint();
+const DATE_FACTOR = 1000000n;
+const DATE_BASE_NS = BigInt(Date.now() + 1) * DATE_FACTOR - 1n;
 const CLOCK_ACCURACY_US = 1; // two process.hrtime() calls take roughly this long, so this is the accuracy we can measure time
 
 /**
@@ -14,16 +14,27 @@ class Clock {
      * @param {Date|number} epoch The epoch to base this clock on, either as a Date or a number of the amount of milliseconds since the unix epoch
      */
     constructor(epoch) {
-        this.epoch = Math.floor((epoch instanceof Date ? epoch.getTime() : Number(epoch)) * 1000.0);
+        this.epoch = BigInt(epoch instanceof Date ? epoch.getTime() : Number(epoch)) * DATE_FACTOR;
+        this.lastTime = 0;
     }
 
     /**
-     * @returns {number} The number of microseconds since the epoch given in the constructor. The decimal part denotes the accuracy of the clock in milliseconds.
-     * @note Needs to allow at least tens of ms accuracy, better hundreds of ms
+     * @returns {number} The number of microseconds since the epoch given in the constructor.
+     * @note Needs to allow at least tenths of ms accuracy, better hundredths of ms
      */
     time() {
-        const delta = process.hrtime(TIME_BASE);
-        return DATE_BASE_US - this.epoch + (delta[0] * US_PER_SEC + Math.floor(delta[1] / 1000)) + (CLOCK_ACCURACY_US / 1000.0);
+        const delta = process.hrtime.bigint() - TIME_BASE;
+        const timeSinceEpoch = Number((DATE_BASE_NS - this.epoch + delta) / 1000n);
+        return this.lastTime = Math.max(this.lastTime + 1, timeSinceEpoch);
+    }
+
+    /**
+     * Return the clock accuracy of the given timestamp.
+     * @param {number} time A timestamp measured by this clock.
+     * @returns {number} The amount of µs accuracy this timestamp has.
+     */
+    accuracy(time) {
+        return CLOCK_ACCURACY_US;
     }
 
 }

--- a/test/Clock.spec.js
+++ b/test/Clock.spec.js
@@ -55,4 +55,16 @@ describe('Clock', function() {
 
 	});
 
+	describe('accuracy', function() {
+
+		it('returns the accuracy of the clock in ms', function() {
+			const HundredYearsInMs = 100 * 365 * 24 * 3600 * 1000;
+			const clock = new Clock(Date.now() - HundredYearsInMs);
+
+			expect(clock.accuracy(clock.time())).to.be.greaterThan(0);
+			expect(clock.accuracy(clock.time())).to.be.lessThan(100);
+		});
+
+	});
+
 });

--- a/test/Clock.spec.js
+++ b/test/Clock.spec.js
@@ -1,0 +1,58 @@
+const expect = require('expect.js');
+const Clock = require('../src/Clock');
+
+describe('Clock', function() {
+
+	it('can be constructed with a numeric clock timestamp', function() {
+		const now = Date.now();
+		const clock = new Clock(now);
+		expect(clock.time()).to.be.greaterThan(1);
+	});
+
+	it('can be constructed with a Date', function() {
+		const now = new Date();
+		const clock = new Clock(now);
+		expect(clock.time()).to.be.greaterThan(1);
+	});
+
+	describe('time', function() {
+
+		const MS_FACTOR = 1000.0;
+
+		it('returns a microseconds timestamp', function() {
+			const oneHourMs = 3600 * 1000;
+			const clock = new Clock(Date.now() - oneHourMs);
+			const time = clock.time() / MS_FACTOR;
+			expect(time).to.be.within(oneHourMs, oneHourMs + 10);
+		});
+
+		it('returns a monotonic timestamp', function() {
+			const now = Date.now();
+			const clock = new Clock(now);
+			const times = new Array(100);
+			for (let i=0;i<100;i++) {
+				times[i] = clock.time();
+			}
+			for (let i=1;i<times.length;i++){
+				expect(times[i]).to.be.greaterThan(times[i-1]);
+			}
+		});
+
+		it('measures at least 100 years', function() {
+			const HundredYearsInMs = 100 * 365 * 24 * 3600 * 1000;
+			const clock = new Clock(Date.now() - HundredYearsInMs);
+			const time = clock.time() / MS_FACTOR;
+			expect(time).to.be.within(HundredYearsInMs, HundredYearsInMs + 10);
+
+			const times = new Array(100);
+			for (let i=0;i<100;i++) {
+				times[i] = clock.time();
+			}
+			for (let i=1;i<times.length;i++){
+				expect(times[i]).to.be.greaterThan(times[i-1]);
+			}
+		});
+
+	});
+
+});


### PR DESCRIPTION
Due to reduction of accuracy of the hrtime based clock to microseconds, the clock was no longer monotonic.

This fixes that, makes use of `hrtime.bigint()` (see https://github.com/albe/node-event-storage/issues/72#issuecomment-549078892) and removes the decimal-encoded clock accuracy, which was not preserved for high clock ticks anyway (only up to ~30 years, which is likely still sufficient, but not guaranteed).

Also, this adds tests for the Clock to verify monotonicity and that it can cover at minimum 100 years (from it's epoch into the future).