### PR TITLE
Fix streams for node 16.3

### DIFF
--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -45,13 +45,14 @@ class EventStream extends stream.Readable {
             this.minRevision = normalizeVersion(minRevision, this.streamIndex.length);
             this.maxRevision = normalizeVersion(maxRevision, this.streamIndex.length);
             this.version = minVersion(this.streamIndex.length, maxRevision);
+            this._iterator = null;
             this.fetch = function() {
                 return eventStore.storage.readRange(this.minRevision, this.maxRevision, this.streamIndex);
             }
         } else {
             this.streamIndex = { length: 0 };
             this.version = -1;
-            this.iterator = { next() { return { done: true }; } };
+            this._iterator = { next() { return { done: true }; } };
         }
     }
 
@@ -238,7 +239,7 @@ class EventStream extends stream.Readable {
      * @returns {EventStream}
      */
     reset() {
-        this.iterator = null;
+        this._iterator = null;
         this._events = null;
         return this;
     }
@@ -247,12 +248,12 @@ class EventStream extends stream.Readable {
      * @returns {object|boolean} The next event or false if no more events in the stream.
      */
     next() {
-        if (!this.iterator) {
-            this.iterator = this.fetch();
+        if (!this._iterator) {
+            this._iterator = this.fetch();
         }
         let next;
         try {
-            next = this.iterator.next();
+            next = this._iterator.next();
         } catch(e) {
             return false;
         }

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -47,7 +47,7 @@ class JoinEventStream extends EventStream {
                 return eventStore.storage.readRange(from, until, streamIndex);
             });
         }
-        this.iterator = null;
+        this._iterator = null;
     }
 
     /**
@@ -56,7 +56,7 @@ class JoinEventStream extends EventStream {
      * @returns {*}
      */
     getValue(index) {
-        const next = this.iterator[index].next();
+        const next = this._iterator[index].next();
         return next.done ? false : next.value;
     }
 
@@ -75,8 +75,8 @@ class JoinEventStream extends EventStream {
      * @returns {object|boolean} The next event or false if no more events in the stream.
      */
     next() {
-        if (!this.iterator) {
-            this.iterator = this.fetch();
+        if (!this._iterator) {
+            this._iterator = this.fetch();
         }
         let nextIndex = -1;
         this._next.forEach((value, index) => {


### PR DESCRIPTION
Node 16.3 introduced the `iterator()` method on the streams interface, which interfered with EventStream's internal `iterator` property. This change renames the internal property to `_iterator` to make this compatible with node 16.3+