### PR TITLE
fix: resolve race condition crashing read-only live-watch reader

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -597,6 +597,8 @@ new Storage.ReadOnly([storageName], [config])
 
 Accepts the same options as `Storage` (writable) except for write-specific fields (`writeBufferSize`, `maxWriteBufferDocuments`, `syncOnFlush`, `dirtyReads`, `partitioner`, `lock`).  In addition to the read API it watches the data directory for new partitions and index files created by a concurrent writer.
 
+> **Note:** Read-only live change detection relies on reliable **recursive** `fs.watch` support in Node.js. This is currently available on Windows, macOS, and Linux (Node.js runtime support required).
+
 ### Shared methods (readable and writable)
 
 #### `open()` ✅ Stable

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,28 @@ graph TD
 
 ---
 
+## Watcher and Read-Only Runtime Synchronization
+
+The current watcher model is intentionally minimal and optimized for the EventStore runtime:
+
+- `DirectoryWatcher` is a reference-counted singleton per `(directory, recursive)` pair and uses fixed `fs.watch` behavior (`persistent: false`, `encoding: 'utf8'`).
+- `DirectoryWatcher` normalizes incoming file names to storage-relative, slash-separated paths (`'/'`), including Windows-specific absolute/namespace-prefixed paths.
+- `Watcher` registers a per-subscriber filename resolver/filter at `DirectoryWatcher` level, so events are filtered before they reach most subscribers.
+- Single-file watchers use a root-relative `fixedFilename` (not `basename`) so hierarchical paths like `a/b/c.index` are matched deterministically.
+- `rootDirectory` in single-file mode serves two purposes: it defines the relative filename space and ensures file watchers share a single root `DirectoryWatcher` instead of opening nested directory watchers.
+
+Read-only synchronization is event-driven, with a bounded rescan fallback for missing filenames:
+
+- `ReadOnlyStorage` watches both data and index roots and reacts to `rename` events for new partitions/indexes.
+- `change` events without filename are treated as a resync signal and are throttled via `scheduleScan()` to avoid scan storms.
+- `ReadOnlyIndex`/`ReadOnlyPartition` are wired through `WatchesFile`; stream and partition updates are propagated via index append events.
+- For ambiguous fs events without a filename, the primary index watcher performs a file-size check and still reacts, so read-only storage stays in sync for runtime propagation.
+- Non-primary index/partition watchers may ignore ambiguous missing-filename events and can temporarily lag until the next explicit filename event or on-demand read sync.
+
+This design keeps watch fan-out low, preserves canonical stream names across platforms, and avoids expensive global filesystem checks on the hot path.
+
+---
+
 ## Technical Decisions
 
 ### Synchronous API

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   ],
   "engines": {
-    "node": ">=18.0"
+    "node": ">=20.0"
   },
   "dependencies": {
     "mkdirp": "^3.0.1"

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -139,7 +139,9 @@ class EventStore extends events.EventEmitter {
             : new Storage(storeName, storageConfig);
 
         this.mountStorage(storage, () => {
-            this.checkUnfinishedCommits();
+            if (storageConfig.readOnly !== true) {
+                this.checkUnfinishedCommits();
+            }
             this.emit('ready');
         });
     }

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -7,7 +7,7 @@ import Storage, { ReadOnly as ReadOnlyStorage, LOCK_THROW, LOCK_RECLAIM } from '
 import Index from './Index.js';
 import Consumer from './Consumer.js';
 import { assert, getPropertyAtPath } from './utils/util.js';
-import { ensureDirectory, scanForFiles } from './utils/fsUtil.js';
+import { ensureDirectory, resolvePath, scanForFiles } from './utils/fsUtil.js';
 import { buildTypeMatcherFn } from './utils/metadataUtil.js';
 import { fixCommitArgumentTypes, parseStreamFromIndexName, normalizePredicateRaw } from './utils/apiHelpers.js';
 
@@ -90,7 +90,7 @@ class EventStore extends events.EventEmitter {
             this.typeMatcherFn = null;
         }
 
-        this.storageDirectory = path.resolve(config.storageDirectory || /* istanbul ignore next */ './data');
+        this.storageDirectory = resolvePath(config.storageDirectory || /* istanbul ignore next */ './data');
         let defaults = {
             dataDirectory: this.storageDirectory,
             indexDirectory: config.streamsDirectory || path.join(this.storageDirectory, 'streams'),
@@ -130,7 +130,7 @@ class EventStore extends events.EventEmitter {
      */
     initialize(storeName, storageConfig) {
         this.storageConfig = storageConfig;
-        this.streamsDirectory = path.resolve(storageConfig.indexDirectory);
+        this.streamsDirectory = resolvePath(storageConfig.indexDirectory);
         this.storeName = storeName;
         this.consumers = new Map();
 

--- a/src/Index/ReadOnlyIndex.js
+++ b/src/Index/ReadOnlyIndex.js
@@ -13,6 +13,19 @@ class ReadOnlyIndex extends watchesFile(ReadableIndex) {
      */
     constructor(name, options) {
         super(name, options);
+        this.syncOnMissingWatchFilename = !!options?.syncOnMissingWatchFilename;
+    }
+
+    /**
+     * @private
+     * @param {string} filename
+     * @returns {boolean}
+     */
+    watchFileFilter(filename) {
+        if (!filename) {
+            return this.syncOnMissingWatchFilename && this.readFileLength() !== this.data.length;
+        }
+        return filename === this.name;
     }
 
     /**

--- a/src/Index/ReadableIndex.js
+++ b/src/Index/ReadableIndex.js
@@ -1,9 +1,9 @@
 import fs from 'fs';
-import path from 'path';
 import events from 'events';
 import Entry, { assertValidEntryClass } from '../IndexEntry.js';
 import { assert, wrapAndCheck, binarySearch } from '../utils/util.js';
 import { normalizeNamedCtorArgs } from '../utils/apiHelpers.js';
+import { resolvePath } from "../utils/fsUtil.js";
 
 // node-event-store-index V01
 const HEADER_MAGIC = "nesidx01";
@@ -69,7 +69,7 @@ class ReadableIndex extends events.EventEmitter {
         this.fileMode = 'r';
         this.EntryClass = options.EntryClass;
         this.dataDirectory = options.dataDirectory;
-        this.fileName = path.resolve(options.dataDirectory, this.name);
+        this.fileName = resolvePath(options.dataDirectory, this.name);
         this.readBuffer = Buffer.allocUnsafe(Math.max(options.EntryClass.size, options.writeBufferSize > 0 ? options.writeBufferSize : 4096));
 
         if (options.metadata) {

--- a/src/Partition/ReadablePartition.js
+++ b/src/Partition/ReadablePartition.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import events from 'events';
 import { assert, alignTo, hash, binarySearch } from '../utils/util.js';
+import { resolvePath } from "../utils/fsUtil.js";
 
 
 
@@ -50,7 +51,7 @@ class ReadablePartition extends events.EventEmitter {
             readBufferSize: DEFAULT_READ_BUFFER_SIZE
         };
         config = Object.assign(defaults, config);
-        this.dataDirectory = path.resolve(config.dataDirectory);
+        this.dataDirectory = resolvePath(config.dataDirectory);
 
         this.name = name;
         this.id = ReadablePartition.idFor(name);

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -24,7 +24,7 @@ class ReadOnlyStorage extends ReadableStorage {
      * @returns {boolean}
      */
     storageFilesFilter(filename) {
-        return !filename.endsWith('.branch') && filename.substring(0, this.storageFile.length) === this.storageFile;
+        return !filename.endsWith('.branch') && filename.substring(0, this.storageFile.length + 1) === this.storageFile + '.';
     }
 
     /**

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -1,7 +1,7 @@
 import ReadableStorage from './ReadableStorage.js';
-import ReadablePartition from '../Partition/ReadablePartition.js';
 import Watcher from '../Watcher.js';
-import { scanForFilesSync } from '../utils/fsUtil.js';
+
+const DEFAULT_SCAN_DELAY_MS = 10;
 
 /**
  * An append-only storage with highly performant positional range scans.
@@ -24,7 +24,7 @@ class ReadOnlyStorage extends ReadableStorage {
      * @returns {boolean}
      */
     storageFilesFilter(filename) {
-        return !filename.endsWith('.branch') && filename.substring(0, this.storageFile.length + 1) === this.storageFile + '.';
+        return !filename.endsWith('.branch') && (filename === this.storageFile || filename.substring(0, this.storageFile.length + 1) === this.storageFile + '.');
     }
 
     /**
@@ -40,8 +40,33 @@ class ReadOnlyStorage extends ReadableStorage {
         if (!this.watcher) {
             this.watcher = new Watcher([this.dataDirectory, this.indexDirectory], this.storageFilesFilter);
             this.watcher.on('rename', this.onStorageFileChanged);
+            // Emit change events without filename as a signal to resync
+            this.watcher.on('change', (filename) => !filename && this.this.scheduleScan());
         }
         return super.open(callback);
+    }
+
+    /**
+     * Schedule a fresh scan of the filesystem to get the ReadOnly instance in sync.
+     * Scheduling will be throttled so multiple calls will not cause multiple scan operations.
+     * Note though that the callback will not be deduplicated, so calling this repeatedly with the same callback will
+     * lead to this callback being executed multiple times once the scan is finished.
+     *
+     * @param {function} [callback] If provided, will be added to the callbacks invoked after the next full scan.
+     * @param {number} [time=SCAN_DELAY_MS] The delay in ms to schedule the scan for
+     */
+    scheduleScan(callback, time = DEFAULT_SCAN_DELAY_MS) {
+        if (typeof callback === 'function') {
+            this.onScanFinished = this.onScanFinished || [];
+            this.onScanFinished.push(callback);
+        }
+        this.scanSchedule = this.scanSchedule || setTimeout(() =>
+            this.scanFiles(() => {
+                this.scanSchedule = null;
+                const callbacks = this.onScanFinished.slice();
+                this.onScanFinished = [];
+                callbacks.forEach(callback => callback());
+            }), typeof callback === 'number' ? callback : time);
     }
 
     /**
@@ -57,49 +82,6 @@ class ReadOnlyStorage extends ReadableStorage {
         }
 
         this.registerPartitionFile(filename);
-    }
-
-    /**
-     * Register a partition by its relative file name if it is not already known.
-     * Shared by the file-watch path and the index-append path so both stay consistent.
-     *
-     * @private
-     * @param {string} filename
-     * @returns {number} The id of the (now registered) partition.
-     */
-    registerPartitionFile(filename) {
-        const partitionId = ReadablePartition.idFor(filename);
-        if (!this.partitions.has(partitionId)) {
-            const partition = this.createPartition(filename, this.partitionConfig);
-            this.partitions.add(partition.id, partition);
-            this.emit('partition-created', partition.id);
-        }
-        return partitionId;
-    }
-
-    /**
-     * Ensure the partition referenced by an appended index entry is registered.
-     *
-     * The index file and the partition file are watched independently, so an `'append'` can be
-     * observed before the corresponding partition-creation event has been dispatched. The writer
-     * always flushes the partition before appending to the index, so the file already exists on
-     * disk; a one-off synchronous scan registers it on demand and closes the race.
-     *
-     * @private
-     * @param {number} partitionId
-     * @returns {boolean} True if the partition is registered after this call.
-     */
-    ensurePartitionRegistered(partitionId) {
-        if (this.partitions.has(partitionId)) {
-            return true;
-        }
-        const escaped = this.storageFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const partitionPattern = new RegExp(`^(${escaped}.*)$`);
-        scanForFilesSync(this.dataDirectory, partitionPattern, (file) => {
-            if (file.endsWith('.index') || file.endsWith('.branch') || file.endsWith('.lock')) return;
-            this.registerPartitionFile(file);
-        });
-        return this.partitions.has(partitionId);
     }
 
     /**
@@ -162,25 +144,14 @@ class ReadOnlyStorage extends ReadableStorage {
     processAppendedEntries(index, indexShortName, entries, startIndex = 0) {
         for (let i = startIndex; i < entries.length; i++) {
             const entry = entries[i];
-            if (!this.ensurePartitionRegistered(entry.partition)) {
-                this.scheduleAppendRetry(index, indexShortName, entries, i);
+            if (!this.partitions.has(entry.partition)) {
+                this.scheduleScan(() => {
+                    this.processAppendedEntries(index, indexShortName, entries, i);
+                });
                 return;
             }
             this.emitAppendedEntry(index, indexShortName, entry);
         }
-    }
-
-    /**
-     * Re-process appended entries from the given offset on the next tick.
-     * @private
-     */
-    scheduleAppendRetry(index, indexShortName, entries, startIndex) {
-        setTimeout(() => {
-            if (!this.watcher) {
-                return;
-            }
-            this.processAppendedEntries(index, indexShortName, entries, startIndex);
-        }, 1);
     }
 
     /**
@@ -193,10 +164,8 @@ class ReadOnlyStorage extends ReadableStorage {
         try {
             document = this.readFrom(entry.partition, entry.position, entry.size);
         } catch (error) {
-            /* c8 ignore next 3 */
-            if (this.listenerCount('error') > 0) {
-                this.emit('error', error);
-            }
+            /* c8 ignore next  */
+            this.emit('error', error);
             return;
         }
         if (index === this.index) {

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -92,6 +92,11 @@ class ReadOnlyStorage extends ReadableStorage {
      * @returns void
      */
     close() {
+        if (this.scanSchedule) {
+            clearTimeout(this.scanSchedule);
+            this.scanSchedule = null;
+        }
+        this.onScanFinished = [];
         if (this.watcher) {
             this.watcher.close();
             this.watcher = null;

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -24,6 +24,9 @@ class ReadOnlyStorage extends ReadableStorage {
      * @returns {boolean}
      */
     storageFilesFilter(filename) {
+        if (!filename) {
+            return true;
+        }
         return !filename.endsWith('.branch') && (filename === this.storageFile || filename.substring(0, this.storageFile.length + 1) === this.storageFile + '.');
     }
 
@@ -74,6 +77,9 @@ class ReadOnlyStorage extends ReadableStorage {
      * @param {string} filename
      */
     onStorageFileChanged(filename) {
+        if (!filename) {
+            return;
+        }
         if (filename.endsWith('.index')) {
             const indexName = filename.substring(this.storageFile.length + 1, filename.length - 6);
             // New indexes are not automatically opened in the reader

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -1,6 +1,7 @@
 import ReadableStorage from './ReadableStorage.js';
 import ReadablePartition from '../Partition/ReadablePartition.js';
 import Watcher from '../Watcher.js';
+import { scanForFilesSync } from '../utils/fsUtil.js';
 
 /**
  * An append-only storage with highly performant positional range scans.
@@ -55,12 +56,50 @@ class ReadOnlyStorage extends ReadableStorage {
             return;
         }
 
+        this.registerPartitionFile(filename);
+    }
+
+    /**
+     * Register a partition by its relative file name if it is not already known.
+     * Shared by the file-watch path and the index-append path so both stay consistent.
+     *
+     * @private
+     * @param {string} filename
+     * @returns {number} The id of the (now registered) partition.
+     */
+    registerPartitionFile(filename) {
         const partitionId = ReadablePartition.idFor(filename);
         if (!this.partitions.has(partitionId)) {
             const partition = this.createPartition(filename, this.partitionConfig);
             this.partitions.add(partition.id, partition);
             this.emit('partition-created', partition.id);
         }
+        return partitionId;
+    }
+
+    /**
+     * Ensure the partition referenced by an appended index entry is registered.
+     *
+     * The index file and the partition file are watched independently, so an `'append'` can be
+     * observed before the corresponding partition-creation event has been dispatched. The writer
+     * always flushes the partition before appending to the index, so the file already exists on
+     * disk; a one-off synchronous scan registers it on demand and closes the race.
+     *
+     * @private
+     * @param {number} partitionId
+     * @returns {boolean} True if the partition is registered after this call.
+     */
+    ensurePartitionRegistered(partitionId) {
+        if (this.partitions.has(partitionId)) {
+            return true;
+        }
+        const escaped = this.storageFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const partitionPattern = new RegExp(`^(${escaped}.*)$`);
+        scanForFilesSync(this.dataDirectory, partitionPattern, (file) => {
+            if (file.endsWith('.index') || file.endsWith('.branch') || file.endsWith('.lock')) return;
+            this.registerPartitionFile(file);
+        });
+        return this.partitions.has(partitionId);
     }
 
     /**
@@ -97,14 +136,7 @@ class ReadOnlyStorage extends ReadableStorage {
             if (entries === false) {
                 return;
             }
-            for (let entry of entries) {
-                const document = this.readFrom(entry.partition, entry.position, entry.size);
-                if (index === this.index) {
-                    this.emit('wrote', document, entry, entry.position);
-                } else {
-                    this.emit('index-add', indexShortName, entry.number, document);
-                }
-            }
+            this.processAppendedEntries(index, indexShortName, entries);
         });
         index.on('truncate', (prevLength, newLength) => {
             if (index === this.index) {
@@ -112,6 +144,66 @@ class ReadOnlyStorage extends ReadableStorage {
             }
         });
         return { index };
+    }
+
+    /**
+     * Emit `'wrote'` / `'index-add'` for each appended index entry.
+     *
+     * If an entry references a partition that has not been registered yet (the partition-creation
+     * watch event is still pending), the remaining entries are re-processed on the next tick instead
+     * of throwing a hard `Partition #… does not exist.` error out of the synchronous emit path.
+     *
+     * @private
+     * @param {ReadableIndex} index
+     * @param {string} indexShortName
+     * @param {IndexEntry[]} entries
+     * @param {number} [startIndex] The entry offset to resume from on a retry.
+     */
+    processAppendedEntries(index, indexShortName, entries, startIndex = 0) {
+        for (let i = startIndex; i < entries.length; i++) {
+            const entry = entries[i];
+            if (!this.ensurePartitionRegistered(entry.partition)) {
+                this.scheduleAppendRetry(index, indexShortName, entries, i);
+                return;
+            }
+            this.emitAppendedEntry(index, indexShortName, entry);
+        }
+    }
+
+    /**
+     * Re-process appended entries from the given offset on the next tick.
+     * @private
+     */
+    scheduleAppendRetry(index, indexShortName, entries, startIndex) {
+        setTimeout(() => {
+            if (!this.watcher) {
+                return;
+            }
+            this.processAppendedEntries(index, indexShortName, entries, startIndex);
+        }, 1);
+    }
+
+    /**
+     * Read a single appended entry and emit the corresponding event.
+     * A read failure is surfaced as an `'error'` event (when observed) rather than crashing the reader.
+     * @private
+     */
+    emitAppendedEntry(index, indexShortName, entry) {
+        let document;
+        try {
+            document = this.readFrom(entry.partition, entry.position, entry.size);
+        } catch (error) {
+            /* c8 ignore next 3 */
+            if (this.listenerCount('error') > 0) {
+                this.emit('error', error);
+            }
+            return;
+        }
+        if (index === this.index) {
+            this.emit('wrote', document, entry, entry.position);
+        } else {
+            this.emit('index-add', indexShortName, entry.number, document);
+        }
     }
 }
 

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -41,7 +41,7 @@ class ReadOnlyStorage extends ReadableStorage {
             this.watcher = new Watcher([this.dataDirectory, this.indexDirectory], this.storageFilesFilter);
             this.watcher.on('rename', this.onStorageFileChanged);
             // Emit change events without filename as a signal to resync
-            this.watcher.on('change', (filename) => !filename && this.this.scheduleScan());
+            this.watcher.on('change', (filename) => !filename && this.scheduleScan());
         }
         return super.open(callback);
     }

--- a/src/Storage/ReadOnlyStorage.js
+++ b/src/Storage/ReadOnlyStorage.js
@@ -63,7 +63,7 @@ class ReadOnlyStorage extends ReadableStorage {
         this.scanSchedule = this.scanSchedule || setTimeout(() =>
             this.scanFiles(() => {
                 this.scanSchedule = null;
-                const callbacks = this.onScanFinished.slice();
+                const callbacks = this.onScanFinished || [];
                 this.onScanFinished = [];
                 callbacks.forEach(callback => callback());
             }), typeof callback === 'number' ? callback : time);

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -127,7 +127,7 @@ class ReadableStorage extends events.EventEmitter {
         this.indexOptions.dataDirectory = this.indexDirectory;
         // Safety precaution to prevent accidentally restricting main index
         delete this.indexOptions.matcher;
-        const { index } = this.createIndex(config.indexFile, this.indexOptions);
+        const { index } = this.createIndex(config.indexFile, Object.assign({}, this.indexOptions, { syncOnMissingWatchFilename: true }));
         this.index = index;
         this.secondaryIndexes = {};
         this.readonlyIndexes = {};

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -4,7 +4,7 @@ import events from 'events';
 import { ReadOnly as ReadOnlyPartition } from '../Partition.js';
 import { ReadOnly as ReadOnlyIndex } from '../Index.js';
 import { assert, wrapAndCheck, iterate, kWayMerge } from '../utils/util.js';
-import { scanForFiles } from '../utils/fsUtil.js';
+import { resolvePath, scanForFiles } from '../utils/fsUtil.js';
 import { createHmac, matches, buildMetadataForMatcher } from '../utils/metadataUtil.js';
 import { normalizeNamedCtorArgs } from '../utils/apiHelpers.js';
 import IndexMatcher from '../IndexMatcher.js';
@@ -78,7 +78,7 @@ class ReadableStorage extends events.EventEmitter {
 
         this.hmac = createHmac(config.hmacSecret);
 
-        this.dataDirectory = path.resolve(config.dataDirectory);
+        this.dataDirectory = resolvePath(config.dataDirectory);
 
         const partitionDefaults = { readBufferSize: DEFAULT_READ_BUFFER_SIZE };
         this.partitionConfig = Object.assign(partitionDefaults, config);
@@ -120,7 +120,7 @@ class ReadableStorage extends events.EventEmitter {
      * @returns void
      */
     initializeIndexes(config) {
-        this.indexDirectory = path.resolve(config.indexDirectory || this.dataDirectory);
+        this.indexDirectory = resolvePath(config.indexDirectory || this.dataDirectory);
 
         this.indexOptions = config.indexOptions;
         this.indexOptions.dataDirectory = this.indexDirectory;

--- a/src/Storage/ReadableStorage.js
+++ b/src/Storage/ReadableStorage.js
@@ -9,6 +9,7 @@ import { createHmac, matches, buildMetadataForMatcher } from '../utils/metadataU
 import { normalizeNamedCtorArgs } from '../utils/apiHelpers.js';
 import IndexMatcher from '../IndexMatcher.js';
 import PartitionPool from '../PartitionPool.js';
+import ReadablePartition from "../Partition/ReadablePartition.js";
 
 const DEFAULT_READ_BUFFER_SIZE = 4 * 1024;
 
@@ -144,6 +145,24 @@ class ReadableStorage extends events.EventEmitter {
     }
 
     /**
+     * Register a partition by its relative file name if it is not already known.
+     * Shared by the file-watch path and the initial scan so both stay consistent.
+     *
+     * @protected
+     * @param {string} filename
+     * @returns {number} The id of the (now registered) partition.
+     */
+    registerPartitionFile(filename) {
+        const partitionId = ReadablePartition.idFor(filename);
+        if (!this.partitions.has(partitionId)) {
+            const partition = this.createPartition(filename, this.partitionConfig);
+            this.partitions.add(partition.id, partition);
+            this.emit('partition-created', partition.id);
+        }
+        return partitionId;
+    }
+
+    /**
      * Scan partitions and secondary index files; emit 'index-created' for each found index.
      * @param {function} done Called when both scans finish.
      */
@@ -152,8 +171,7 @@ class ReadableStorage extends events.EventEmitter {
         const partitionPattern = new RegExp(`^(${escaped}.*)$`);
         scanForFiles(this.dataDirectory, partitionPattern, (file) => {
             if (file.endsWith('.index') || file.endsWith('.branch') || file.endsWith('.lock')) return;
-            const partition = this.createPartition(file, this.partitionConfig);
-            this.partitions.add(partition.id, partition);
+            this.registerPartitionFile(file);
         }, (partErr) => {
             /* c8 ignore next */
             if (partErr) throw partErr;
@@ -167,7 +185,9 @@ class ReadableStorage extends events.EventEmitter {
             }
             const indexPattern = new RegExp(`^${escaped}\\.(.+)\\.index$`);
             scanForFiles(this.indexDirectory, indexPattern, (name) => {
-                this.emit('index-created', name);
+                if (!(name in this.secondaryIndexes)) {
+                    this.emit('index-created', name);
+                }
             }, (indexErr) => {
                 // The directory could disappear between existsSync and readdir (e.g. test cleanup).
                 /* c8 ignore next */

--- a/src/Storage/WritableStorage.js
+++ b/src/Storage/WritableStorage.js
@@ -66,11 +66,12 @@ class WritableStorage extends ReadableStorage {
     }
 
     /**
-     * @inheritDoc
      * Acquires the write lock synchronously.
      * For LOCK_RECLAIM, removes any orphaned lock before trying to acquire our own; torn-write
      * repair runs after the primary index is open, before `'opened'` is emitted.
      *
+     * @param {function(): void} [callback] Called after indexes open, before `'opened'` is emitted.
+     *   Can be used as a synchronous alternative to listening to the `'opened'` event.
      * @returns {boolean}
      * @throws {StorageLockedError} If this storage is locked by another process.
      */

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -14,25 +14,76 @@ const directoryWatchers = new Map();
 class DirectoryWatcher extends events.EventEmitter {
 
     /**
+     * Normalize fs.watch filenames to be relative to the watched directory.
+     * On Windows recursive watches may yield absolute `\\?\` names or directory names.
+     *
+     * @private
+     * @param {string|Buffer|null} filename
+     * @returns {string}
+     */
+    normalizeFilename(filename) {
+        if (!filename) return '';
+        if (Buffer.isBuffer(filename)) {
+            filename = filename.toString();
+        }
+        if (typeof filename !== 'string' || filename.length === 0) {
+            return '';
+        }
+
+        const stripped = filename
+            .replace(/^\\\\\?\\UNC\\/i, '\\\\')
+            .replace(/^\\\\\?\\/, '');
+        const normalized = path.normalize(stripped);
+
+        if (path.isAbsolute(normalized)) {
+            const relative = path.relative(this.directory, normalized);
+            return relative === '.' ? '' : relative;
+        }
+
+        return normalized === '.' ? '' : normalized;
+    }
+
+    /**
+     * Forward fs.watch events with normalized filenames.
+     *
+     * @private
+     * @param {string} eventType
+     * @param {string|Buffer|null} filename
+     */
+    onFsEvent(eventType, filename) {
+        const normalized = this.normalizeFilename(filename);
+        if (eventType === 'rename' && !filename) {
+            // Close if the watched directory was removed
+            this.close();
+            return;
+        }
+        this.emit(eventType, normalized);
+    }
+
+    /**
      * @param {string} directory
      * @param {object} [options] The options to pass to the fs.watch call. See https://nodejs.org/api/fs.html#fs_fs_watch_filename_options_listener
      * @returns {DirectoryWatcher}
      */
     constructor(directory, options = {}) {
         directory = path.normalize(directory);
+        const watchOptions = Object.assign({ persistent: false, recursive: true, encoding: 'utf8' }, options);
+        const watcherKey = `${directory}|${JSON.stringify(watchOptions)}`;
 
-        if (directoryWatchers.has(directory)) {
-            const watcher = directoryWatchers.get(directory);
+        if (directoryWatchers.has(watcherKey)) {
+            const watcher = directoryWatchers.get(watcherKey);
             watcher.references++;
             return watcher;
         }
         assert(fs.existsSync(directory), `Can not watch a non-existing directory "${directory}".`);
         assert(fs.statSync(directory).isDirectory(), `Can only watch directories, but "${directory}" is none.`);
         super();
-        this.setMaxListeners(1000);
-        directoryWatchers.set(directory, this);
+        this.setMaxListeners(0);
+        directoryWatchers.set(watcherKey, this);
+        this.watcherKey = watcherKey;
         this.directory = directory;
-        this.watcher = fs.watch(directory, Object.assign({ persistent: false }, options), this.emit.bind(this));
+        this.onFsEvent = this.onFsEvent.bind(this);
+        this.watcher = fs.watch(directory, watchOptions, this.onFsEvent);
         this.references = 1;
     }
 
@@ -45,7 +96,7 @@ class DirectoryWatcher extends events.EventEmitter {
         if (this.references === 0 && this.watcher) {
             this.watcher.close();
             this.watcher = null;
-            directoryWatchers.delete(this.directory);
+            directoryWatchers.delete(this.watcherKey);
         }
     }
 
@@ -54,7 +105,7 @@ class DirectoryWatcher extends events.EventEmitter {
 /**
  * A watcher for a single file or a directory, with the possibility to provide a filter method for file names to watch.
  */
-class Watcher {
+class Watcher extends events.EventEmitter {
 
     /**
      * Remove redundant nested directories so each tree is watched only once.
@@ -62,22 +113,53 @@ class Watcher {
      * @private
      * @param {string[]} directories
      * @param {boolean} recursive
-     * @returns {string[]}
+     * @returns {[string[], string[]]} Tuple of [watchedDirectories, removedRelativePrefixes]
      */
     static deduplicateDirectories(directories, recursive = true) {
         const normalized = [...new Set(directories.map(dir => path.resolve(path.normalize(dir))))];
         if (!recursive) {
-            return normalized;
+            return [normalized, []];
         }
         normalized.sort((a, b) => a.length - b.length);
         const deduplicated = [];
+        const removedRelativePrefixes = new Set();
         for (const directory of normalized) {
-            if (deduplicated.some(parent => isSameOrParentDirectory(parent, directory))) {
+            const parent = deduplicated.find(current => isSameOrParentDirectory(current, directory));
+            if (parent) {
+                const relative = path.normalize(path.relative(parent, directory));
+                if (relative && relative !== '.') {
+                    removedRelativePrefixes.add(relative);
+                }
                 continue;
             }
             deduplicated.push(directory);
         }
-        return deduplicated;
+        return [deduplicated, [...removedRelativePrefixes]];
+    }
+
+    /**
+     * Strip the longest matching removed relative prefix from an observed filename.
+     *
+     * @private
+     * @param {string} filename
+     * @returns {string}
+     */
+    normalizeSubDirectoryFilename(filename) {
+        if (!filename || !this.subDirectoryPrefixes || this.subDirectoryPrefixes.length === 0) {
+            return filename;
+        }
+
+        filename = path.normalize(filename);
+        for (const subDirectoryPrefix of this.subDirectoryPrefixes) {
+            if (filename === subDirectoryPrefix) {
+                return '';
+            }
+            const prefix = subDirectoryPrefix + path.sep;
+            if (filename.startsWith(prefix)) {
+                return filename.slice(prefix.length);
+            }
+        }
+        return filename;
     }
 
     /**
@@ -87,17 +169,24 @@ class Watcher {
      * @returns {Watcher}
      */
     constructor(fileOrDirectory, fileFilter = null, watchOptions = null) {
+        super();
+        this.validEventTypes = new Set(['change', 'rename']);
         let directories;
         const options = Object.assign({ recursive: true }, watchOptions);
+        this.subDirectoryPrefixes = [];
         if (typeof fileOrDirectory === 'string') {
             directories = [fileOrDirectory];
             if (!fs.statSync(fileOrDirectory).isDirectory()) {
                 directories = [path.dirname(fileOrDirectory)];
                 const filename = path.basename(fileOrDirectory);
+                this.fixedFilename = filename;
                 fileFilter = changedFilename => changedFilename === filename;
             }
         } else {
-            directories = Watcher.deduplicateDirectories(fileOrDirectory, options.recursive);
+            this.fixedFilename = null;
+            const [deduplicatedDirectories, removedRelativePrefixes] = Watcher.deduplicateDirectories(fileOrDirectory, options.recursive);
+            directories = deduplicatedDirectories;
+            this.subDirectoryPrefixes = removedRelativePrefixes.sort((a, b) => b.length - a.length);
         }
 
         this.watchers = directories.map(dir => new DirectoryWatcher(dir, options));
@@ -113,19 +202,18 @@ class Watcher {
             watcher.on('change', this.onChange);
             watcher.on('rename', this.onRename);
         });
-        this.handlers = { change: [], rename: [] };
     }
 
     /**
-     * Register a new handler that is triggered if the fileFilter matches.
+     * Override to validate against allowed event types.
+     * @override
      * @param {string} eventType
-     * @param {function(string): void} handler A handler method that should be invoked with the filename as argument
-     * @api
+     * @param {function} listener
+     * @returns {Watcher}
      */
-    on(eventType, handler) {
-        assert(eventType in this.handlers, `Event type ${eventType} is unknown. Only 'change' and 'rename' are supported.`);
-
-        this.handlers[eventType].push(handler);
+    on(eventType, listener) {
+        assert(this.validEventTypes.has(eventType), `Event type ${eventType} is unknown. Only 'change' and 'rename' are supported.`);
+        return super.on(eventType, listener);
     }
 
     /**
@@ -133,14 +221,14 @@ class Watcher {
      * @param {string} filename
      */
     onChange(filename) {
-        if (this.handlers.change.length === 0) {
-            return;
+        if (!filename && this.fixedFilename) {
+            filename = this.fixedFilename;
         }
+        filename = this.normalizeSubDirectoryFilename(filename);
         if (!filename || !this.fileFilter(filename)) {
             return;
         }
-        this.handlers.change
-            .forEach((handler) => handler(filename));
+        this.emit('change', filename);
     }
 
     /**
@@ -148,14 +236,14 @@ class Watcher {
      * @param {string} filename
      */
     onRename(filename) {
-        if (this.handlers.rename.length === 0) {
-            return;
+        if (!filename && this.fixedFilename) {
+            filename = this.fixedFilename;
         }
+        filename = this.normalizeSubDirectoryFilename(filename);
         if (!filename || !this.fileFilter(filename)) {
             return;
         }
-        this.handlers.rename
-            .forEach((handler) => handler(filename));
+        this.emit('rename', filename);
     }
 
     /**
@@ -169,7 +257,7 @@ class Watcher {
             watcher.close();
         });
         this.watchers = [];
-        this.handlers = { change: [], rename: [] };
+        this.removeAllListeners();
     }
 
 }

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -11,7 +11,43 @@ const directoryWatchers = new Map();
  * A reference counting singleton nodejs watcher for directories.
  * Emits events 'change' and 'rename' with the file name as argument.
  */
-class DirectoryWatcher extends events.EventEmitter {
+class DirectoryWatcher {
+
+    /**
+     * Register a handler with optional filename resolver.
+     *
+     * @param {function(string, string): void} handler
+     * @param {function(string, string): string|null} [filenameResolver]
+     */
+    registerHandler(handler, filenameResolver = null) {
+        this.subscriptions.set(handler, typeof filenameResolver === 'function' ? filenameResolver : null);
+    }
+
+    /**
+     * Unregister a previously added handler.
+     *
+     * @param {function(string, string): void} handler
+     */
+    unregisterHandler(handler) {
+        this.subscriptions.delete(handler);
+    }
+
+    /**
+     * Dispatch an fs event to matching subscribers.
+     *
+     * @private
+     * @param {'change'|'rename'} eventType
+     * @param {string} filename
+     */
+    dispatch(eventType, filename) {
+        for (const [handler, filenameResolver] of this.subscriptions) {
+            const resolvedFilename = filenameResolver ? filenameResolver(filename, eventType) : filename;
+            if (resolvedFilename === null || resolvedFilename === undefined) {
+                continue;
+            }
+            handler(eventType, resolvedFilename);
+        }
+    }
 
     /**
      * Normalize fs.watch filenames to be relative to the watched directory.
@@ -33,14 +69,15 @@ class DirectoryWatcher extends events.EventEmitter {
         const stripped = filename
             .replace(/^\\\\\?\\UNC\\/i, '\\\\')
             .replace(/^\\\\\?\\/, '');
-        const normalized = path.normalize(stripped);
+        filename = path.normalize(stripped);
 
-        if (path.isAbsolute(normalized)) {
-            const relative = path.relative(this.directory, normalized);
-            return relative === '.' ? '' : relative;
+        if (path.isAbsolute(filename)) {
+            filename = path.relative(this.directory, filename);
         }
-
-        return normalized === '.' ? '' : normalized;
+        if (!filename || filename === '.') {
+            return '';
+        }
+        return filename.replace(/\\/g, '/');
     }
 
     /**
@@ -57,7 +94,7 @@ class DirectoryWatcher extends events.EventEmitter {
             this.close();
             return;
         }
-        this.emit(eventType, normalized);
+        this.dispatch(eventType, normalized);
     }
 
     /**
@@ -66,9 +103,8 @@ class DirectoryWatcher extends events.EventEmitter {
      * @returns {DirectoryWatcher}
      */
     constructor(directory, options = {}) {
-        directory = path.normalize(directory);
-        const watchOptions = Object.assign({ persistent: false, recursive: true, encoding: 'utf8' }, options);
-        const watcherKey = `${directory}|${JSON.stringify(watchOptions)}`;
+        const watchOptions = Object.assign({ recursive: true }, options);
+        const watcherKey = `${directory}|r:${watchOptions.recursive}`;
 
         if (directoryWatchers.has(watcherKey)) {
             const watcher = directoryWatchers.get(watcherKey);
@@ -77,11 +113,10 @@ class DirectoryWatcher extends events.EventEmitter {
         }
         assert(fs.existsSync(directory), `Can not watch a non-existing directory "${directory}".`);
         assert(fs.statSync(directory).isDirectory(), `Can only watch directories, but "${directory}" is none.`);
-        super();
-        this.setMaxListeners(0);
         directoryWatchers.set(watcherKey, this);
         this.watcherKey = watcherKey;
         this.directory = directory;
+        this.subscriptions = new Map();
         this.onFsEvent = this.onFsEvent.bind(this);
         this.watcher = fs.watch(directory, watchOptions, this.onFsEvent);
         this.references = 1;
@@ -102,6 +137,8 @@ class DirectoryWatcher extends events.EventEmitter {
 
 }
 
+const VALID_WATCH_EVENT_TYPES = ['change', 'rename'];
+
 /**
  * A watcher for a single file or a directory, with the possibility to provide a filter method for file names to watch.
  */
@@ -116,7 +153,7 @@ class Watcher extends events.EventEmitter {
      * @returns {[string[], string[]]} Tuple of [watchedDirectories, removedRelativePrefixes]
      */
     static deduplicateDirectories(directories, recursive = true) {
-        const normalized = [...new Set(directories.map(dir => path.resolve(path.normalize(dir))))];
+        const normalized = [...new Set(directories)];
         if (!recursive) {
             return [normalized, []];
         }
@@ -126,7 +163,7 @@ class Watcher extends events.EventEmitter {
         for (const directory of normalized) {
             const parent = deduplicated.find(current => isSameOrParentDirectory(current, directory));
             if (parent) {
-                const relative = path.normalize(path.relative(parent, directory));
+                const relative = path.relative(parent, directory).replace(/\\/g, '/');
                 if (relative && relative !== '.') {
                     removedRelativePrefixes.add(relative);
                 }
@@ -138,69 +175,93 @@ class Watcher extends events.EventEmitter {
     }
 
     /**
-     * Strip the longest matching removed relative prefix from an observed filename.
+     * Resolve a filename to a path relative to the longest matching watched prefix.
      *
      * @private
      * @param {string} filename
      * @returns {string}
      */
-    normalizeSubDirectoryFilename(filename) {
-        if (!filename || !this.subDirectoryPrefixes || this.subDirectoryPrefixes.length === 0) {
-            return filename;
-        }
-
-        filename = path.normalize(filename);
-        for (const subDirectoryPrefix of this.subDirectoryPrefixes) {
-            if (filename === subDirectoryPrefix) {
+    resolveRelativeFilename(filename) {
+        filename = path.normalize(filename).replace(/\\/g, '/');
+        for (const prefix of this.relativePrefixes) {
+            if (filename === prefix) {
                 return '';
             }
-            const prefix = subDirectoryPrefix + path.sep;
-            if (filename.startsWith(prefix)) {
-                return filename.slice(prefix.length);
+            const withSeparator = prefix + '/';
+            if (filename.startsWith(withSeparator)) {
+                return filename.slice(withSeparator.length);
             }
         }
         return filename;
     }
 
     /**
+     * Resolve the final filename used for matching and emitting.
+     * Returns `null` when the filename is filtered out.
+     *
+     * @private
+     * @param {string} filename
+     * @returns {string|null}
+     */
+    resolveFilename(filename) {
+        if (!filename) {
+            if (!this.fileFilter(filename)) {
+                return null;
+            }
+            return this.fixedFilename || '';
+        }
+
+        filename = this.resolveRelativeFilename(filename);
+
+        if (!this.fileFilter(filename)) {
+            return null;
+        }
+        return filename;
+    }
+
+    /**
      * @param {string|string[]} fileOrDirectory The filename or directory or list of directories to watch
-     * @param {function(string): boolean} [fileFilter] A filter that will receive a filename and needs to return true if this watcher should be invoked. Will be ignored if the first argument is a file.
-     * @param {object|null} [watchOptions] Options forwarded to fs.watch for each directory watcher.
+     * @param {function(string): boolean} [fileFilter] A filter that will receive a filename and needs to return true if this watcher should be invoked.
+     * @param {object|null} [options] Internal watcher options.
+     * @param {boolean} [options.recursive=true] Whether directories are watched recursively.
+     * @param {string} [options.rootDirectory] Root directory used to relativize single-file watcher events.
      * @returns {Watcher}
      */
-    constructor(fileOrDirectory, fileFilter = null, watchOptions = null) {
+    constructor(fileOrDirectory, fileFilter = null, options = null) {
         super();
-        this.validEventTypes = new Set(['change', 'rename']);
+        const watchOptions = Object.assign({ recursive: true }, options);
+        delete watchOptions.rootDirectory;
+        this.relativePrefixes = [];
         let directories;
-        const options = Object.assign({ recursive: true }, watchOptions);
-        this.subDirectoryPrefixes = [];
         if (typeof fileOrDirectory === 'string') {
             directories = [fileOrDirectory];
             if (!fs.statSync(fileOrDirectory).isDirectory()) {
-                directories = [path.dirname(fileOrDirectory)];
-                const filename = path.basename(fileOrDirectory);
-                this.fixedFilename = filename;
-                fileFilter = changedFilename => changedFilename === filename;
+                const rootDirectory = options?.rootDirectory || path.dirname(fileOrDirectory);
+
+                directories = [rootDirectory];
+                this.fixedFilename = path.relative(rootDirectory, fileOrDirectory).replace(/\\/g, '/');
+                if (fileFilter === null) {
+                    fileFilter = changedFilename => changedFilename === this.fixedFilename;
+                }
             }
         } else {
             this.fixedFilename = null;
-            const [deduplicatedDirectories, removedRelativePrefixes] = Watcher.deduplicateDirectories(fileOrDirectory, options.recursive);
+            const [deduplicatedDirectories, removedRelativePrefixes] = Watcher.deduplicateDirectories(fileOrDirectory, watchOptions.recursive);
             directories = deduplicatedDirectories;
-            this.subDirectoryPrefixes = removedRelativePrefixes.sort((a, b) => b.length - a.length);
+            this.relativePrefixes = removedRelativePrefixes.sort((a, b) => b.length - a.length);
         }
 
-        this.watchers = directories.map(dir => new DirectoryWatcher(dir, options));
+        this.watchers = directories.map(dir => new DirectoryWatcher(dir, watchOptions));
 
         if (fileFilter === null) {
             fileFilter = () => true;
         }
 
         this.fileFilter = fileFilter;
-        this.onChange = this.onChange.bind(this);
-        this.onRename = this.onRename.bind(this);
+        this.resolveFilename = this.resolveFilename.bind(this);
+        this.emitHandler = this.emit.bind(this);
         this.watchers.forEach(watcher => {
-            watcher.on('change', this.onChange);
-            watcher.on('rename', this.onRename);
+            watcher.registerHandler(this.emitHandler, this.resolveFilename);
         });
     }
 
@@ -212,38 +273,8 @@ class Watcher extends events.EventEmitter {
      * @returns {Watcher}
      */
     on(eventType, listener) {
-        assert(this.validEventTypes.has(eventType), `Event type ${eventType} is unknown. Only 'change' and 'rename' are supported.`);
+        assert(VALID_WATCH_EVENT_TYPES.includes(eventType), `Event type ${eventType} is unknown. Only 'change' and 'rename' are supported.`);
         return super.on(eventType, listener);
-    }
-
-    /**
-     * @private
-     * @param {string} filename
-     */
-    onChange(filename) {
-        if (!filename && this.fixedFilename) {
-            filename = this.fixedFilename;
-        }
-        filename = this.normalizeSubDirectoryFilename(filename);
-        if (!filename || !this.fileFilter(filename)) {
-            return;
-        }
-        this.emit('change', filename);
-    }
-
-    /**
-     * @private
-     * @param {string} filename
-     */
-    onRename(filename) {
-        if (!filename && this.fixedFilename) {
-            filename = this.fixedFilename;
-        }
-        filename = this.normalizeSubDirectoryFilename(filename);
-        if (!filename || !this.fileFilter(filename)) {
-            return;
-        }
-        this.emit('rename', filename);
     }
 
     /**
@@ -252,8 +283,7 @@ class Watcher extends events.EventEmitter {
      */
     close() {
         this.watchers.forEach(watcher => {
-            watcher.removeListener('change', this.onChange);
-            watcher.removeListener('rename', this.onRename);
+            watcher.unregisterHandler(this.emitHandler);
             watcher.close();
         });
         this.watchers = [];

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import events from 'events';
 import { assert } from './utils/util.js';
+import { isSameOrParentDirectory } from "./utils/fsUtil.js";
 
 /** @type {Map<string, DirectoryWatcher>} */
 const directoryWatchers = new Map();
@@ -56,12 +57,38 @@ class DirectoryWatcher extends events.EventEmitter {
 class Watcher {
 
     /**
+     * Remove redundant nested directories so each tree is watched only once.
+     *
+     * @private
+     * @param {string[]} directories
+     * @param {boolean} recursive
+     * @returns {string[]}
+     */
+    static deduplicateDirectories(directories, recursive = true) {
+        const normalized = [...new Set(directories.map(dir => path.resolve(path.normalize(dir))))];
+        if (!recursive) {
+            return normalized;
+        }
+        normalized.sort((a, b) => a.length - b.length);
+        const deduplicated = [];
+        for (const directory of normalized) {
+            if (deduplicated.some(parent => isSameOrParentDirectory(parent, directory))) {
+                continue;
+            }
+            deduplicated.push(directory);
+        }
+        return deduplicated;
+    }
+
+    /**
      * @param {string|string[]} fileOrDirectory The filename or directory or list of directories to watch
      * @param {function(string): boolean} [fileFilter] A filter that will receive a filename and needs to return true if this watcher should be invoked. Will be ignored if the first argument is a file.
+     * @param {object|null} [watchOptions] Options forwarded to fs.watch for each directory watcher.
      * @returns {Watcher}
      */
-    constructor(fileOrDirectory, fileFilter = null) {
+    constructor(fileOrDirectory, fileFilter = null, watchOptions = null) {
         let directories;
+        const options = Object.assign({ recursive: true }, watchOptions);
         if (typeof fileOrDirectory === 'string') {
             directories = [fileOrDirectory];
             if (!fs.statSync(fileOrDirectory).isDirectory()) {
@@ -70,10 +97,10 @@ class Watcher {
                 fileFilter = changedFilename => changedFilename === filename;
             }
         } else {
-            directories = [...new Set(fileOrDirectory.map(path.normalize))];
+            directories = Watcher.deduplicateDirectories(fileOrDirectory, options.recursive);
         }
 
-        this.watchers = directories.map(dir => new DirectoryWatcher(dir));
+        this.watchers = directories.map(dir => new DirectoryWatcher(dir, options));
 
         if (fileFilter === null) {
             fileFilter = () => true;

--- a/src/WatchesFile.js
+++ b/src/WatchesFile.js
@@ -14,7 +14,10 @@ const WatchesFile = Base => class extends Base {
      */
     watchFile() {
         this.stopWatching();
-        this.watcher = new Watcher(this.fileName);
+        const fileFilter = typeof this.watchFileFilter === 'function'
+            ? this.watchFileFilter.bind(this)
+            : null;
+        this.watcher = new Watcher(this.fileName, fileFilter, { rootDirectory: this.dataDirectory });
         this.watcher.on('change', this.onChange.bind(this));
         this.watcher.on('rename', this.onRename.bind(this));
     }

--- a/src/utils/fsUtil.js
+++ b/src/utils/fsUtil.js
@@ -121,7 +121,46 @@ function scanForFiles(directory, regexPattern, onEach, onDone) {
     scanDir(directory, '', true, regexPattern, onEach, onDone);
 }
 
+/**
+ * Synchronously scan one directory level, then recurse into subdirectories.
+ *
+ * @param {string} dir Absolute directory path.
+ * @param {string} relativePrefix Relative prefix for match paths.
+ * @param {boolean} isRoot True for the initial call.
+ * @param {RegExp} regexPattern Regex for file paths.
+ * @param {function(string): void} onEach Callback for matching files.
+ * @returns {void}
+ */
+function scanDirSync(dir, relativePrefix, isRoot, regexPattern, onEach) {
+    let entries;
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+        if (!isRoot && err.code === 'ENOENT') return;
+        throw err;
+    }
+    const subdirs = classifyEntries(entries, relativePrefix, regexPattern, onEach);
+    for (const name of subdirs) {
+        scanDirSync(path.join(dir, name), relativePrefix + name + '/', false, regexPattern, onEach);
+    }
+}
+
+/**
+ * Synchronous counterpart to {@link scanForFiles}. Used on cold paths where a blocking scan is
+ * acceptable and the result is needed immediately (e.g. lazily registering a partition referenced
+ * by a freshly appended index entry during live watching).
+ *
+ * @param {string} directory The root directory to scan.
+ * @param {RegExp} regexPattern The pattern to match relative file paths against.
+ * @param {function(string)} onEach Called with the first capturing group (or full match) for each matching path.
+ * @returns {void}
+ */
+function scanForFilesSync(directory, regexPattern, onEach) {
+    scanDirSync(directory, '', true, regexPattern, onEach);
+}
+
 export {
     ensureDirectory,
     scanForFiles,
+    scanForFilesSync,
 };

--- a/src/utils/fsUtil.js
+++ b/src/utils/fsUtil.js
@@ -1,6 +1,18 @@
 import fs from 'fs';
+import os from "os";
 import path from 'path';
 import { mkdirpSync } from 'mkdirp';
+
+/**
+ * Resolve a file or directory path, supporting `~/` for the user's home directory and joining with additional path segments.
+ * @param {string} fileOrDirectory
+ * @param {string} [directories]
+ * @returns {string} The normalized path, with resolved relative and home directory references.
+ */
+function resolvePath(fileOrDirectory, ...directories) {
+    fileOrDirectory = fileOrDirectory.replace(/^~\//, os.homedir() + '/');
+    return path.resolve(fileOrDirectory, ...directories);
+}
 
 /**
  * Ensure that the given directory exists.
@@ -160,6 +172,7 @@ function scanForFilesSync(directory, regexPattern, onEach) {
 }
 
 export {
+    resolvePath,
     ensureDirectory,
     scanForFiles,
     scanForFilesSync,

--- a/src/utils/fsUtil.js
+++ b/src/utils/fsUtil.js
@@ -134,46 +134,21 @@ function scanForFiles(directory, regexPattern, onEach, onDone) {
 }
 
 /**
- * Synchronously scan one directory level, then recurse into subdirectories.
+ * Return true when both paths are equal or `child` is nested inside `parent`.
  *
- * @param {string} dir Absolute directory path.
- * @param {string} relativePrefix Relative prefix for match paths.
- * @param {boolean} isRoot True for the initial call.
- * @param {RegExp} regexPattern Regex for file paths.
- * @param {function(string): void} onEach Callback for matching files.
- * @returns {void}
+ * @private
+ * @param {string} parent
+ * @param {string} child
+ * @returns {boolean}
  */
-function scanDirSync(dir, relativePrefix, isRoot, regexPattern, onEach) {
-    let entries;
-    try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (err) {
-        if (!isRoot && err.code === 'ENOENT') return;
-        throw err;
-    }
-    const subdirs = classifyEntries(entries, relativePrefix, regexPattern, onEach);
-    for (const name of subdirs) {
-        scanDirSync(path.join(dir, name), relativePrefix + name + '/', false, regexPattern, onEach);
-    }
-}
-
-/**
- * Synchronous counterpart to {@link scanForFiles}. Used on cold paths where a blocking scan is
- * acceptable and the result is needed immediately (e.g. lazily registering a partition referenced
- * by a freshly appended index entry during live watching).
- *
- * @param {string} directory The root directory to scan.
- * @param {RegExp} regexPattern The pattern to match relative file paths against.
- * @param {function(string)} onEach Called with the first capturing group (or full match) for each matching path.
- * @returns {void}
- */
-function scanForFilesSync(directory, regexPattern, onEach) {
-    scanDirSync(directory, '', true, regexPattern, onEach);
+function isSameOrParentDirectory(parent, child) {
+    const relative = path.relative(parent, child);
+    return !relative || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
 export {
     resolvePath,
     ensureDirectory,
     scanForFiles,
-    scanForFilesSync,
+    isSameOrParentDirectory
 };

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -2,12 +2,36 @@ import expect from 'expect.js';
 import fs from 'fs-extra';
 import fsSync from 'fs';
 import path from 'path';
-import EventStore, { ExpectedVersion, OptimisticConcurrencyError, CommitCondition, LOCK_RECLAIM } from '../src/EventStore.js';
+import EventStoreBase, { ExpectedVersion, OptimisticConcurrencyError, CommitCondition, LOCK_RECLAIM } from '../src/EventStore.js';
 import Consumer from '../src/Consumer.js';
 import { fileURLToPath } from 'url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const storageDirectory = __dirname + 'data';
+
+const eventstores = [];
+
+class EventStore extends EventStoreBase {
+    constructor(...args) {
+        super(...args);
+        eventstores.push(this);
+    }
+}
+
+function createEventStore(storeName = 'eventstore', config = {}) {
+    if (typeof storeName !== 'string') {
+        config = storeName;
+        storeName = 'eventstore';
+    }
+    return new EventStore(storeName, config);
+}
+
+function createReader(config = {}) {
+    return createEventStore(Object.assign({
+        storageDirectory,
+        readOnly: true
+    }, config));
+}
 
 describe('EventStore', function() {
 
@@ -15,12 +39,20 @@ describe('EventStore', function() {
 
     beforeEach(function () {
         fs.emptyDirSync(storageDirectory);
+        eventstores.length = 0;
     });
 
     afterEach(function () {
-        if (eventstore) {
-            eventstore.close();
+        const closedStores = new Set();
+        for (let i = eventstores.length - 1; i >= 0; i--) {
+            const store = eventstores[i];
+            if (!store || closedStores.has(store)) {
+                continue;
+            }
+            closedStores.add(store);
+            store.close();
         }
+        eventstores.length = 0;
         eventstore = null;
     });
 
@@ -112,7 +144,6 @@ describe('EventStore', function() {
                 eventstore2.on('ready', () => {
                     expect(eventstore2.length).to.be(0);
                     expect(eventstore2.getStreamVersion('foo-bar')).to.be(0);
-                    eventstore2.close();
                     done();
                 });
             });
@@ -236,7 +267,6 @@ describe('EventStore', function() {
                         expect(eventstore2.length).to.be(committedEvents.length);
                         // The secondary stream index for stream-b must also be repaired
                         expect(eventstore2.getStreamVersion('stream-b')).to.be(0);
-                        eventstore2.close();
                         done();
                     });
                 });
@@ -270,7 +300,6 @@ describe('EventStore', function() {
                     for (let event of stream) {
                         expect(event).to.eql(events[i++]);
                     }
-                    readstore.close();
                     done();
                 });
             });
@@ -684,7 +713,6 @@ describe('EventStore', function() {
             readstore.on('stream-available', (streamName) => {
                 if (streamName === 'foo') {
                     expect(readstore.getStreamVersion('foo')).to.be(0);
-                    readstore.close();
                     done();
                 }
             });
@@ -1008,6 +1036,40 @@ describe('EventStore', function() {
 
     describe('hierarchical (slash-separated) streams', function() {
 
+        it('read-only instance recognizes newly created hierarchical streams and subsequent writes', function(done) {
+            eventstore = createEventStore({
+                storageDirectory,
+                storageConfig: { syncOnFlush: true }
+            });
+
+            const readstore = createReader();
+
+            readstore.on('ready', () => {
+                expect(readstore.getStreamVersion('a/b/c')).to.be(-1);
+
+                readstore.storage.once('index-add', (indexName, position, document) => {
+                    expect(indexName).to.be('stream-a/b/c');
+                    expect(position).to.be(1);
+                    expect(document.stream).to.be('a/b/c');
+                    expect(document.payload).to.eql({ val: 1 });
+                    expect(readstore.getStreamVersion('a/b/c')).to.be(1);
+                    const stream = readstore.getEventStream('a/b/c');
+                    expect([...stream]).to.eql([{ val: 1 }]);
+                    done();
+                });
+
+                readstore.once('stream-available', (streamName) => {
+                    expect(streamName).to.be('a/b/c');
+                    expect(readstore.getStreamVersion('a/b/c')).to.be(0);
+                    eventstore.commit('a/b/c', [{ val: 1 }], () => {
+                        eventstore.storage.flush();
+                    });
+                });
+
+                eventstore.createEventStream('a/b/c', () => true);
+            });
+        });
+
         it('persists slash-separated streams across store re-open', function (done) {
             eventstore = new EventStore({
                 storageDirectory
@@ -1092,7 +1154,6 @@ describe('EventStore', function() {
                 readOnly: true
             });
             expect(() => readstore.createEventStream('foo-bar', () => true)).to.throwError();
-            readstore.close();
         });
 
         it('throws when trying to re-create stream', function () {
@@ -1119,7 +1180,6 @@ describe('EventStore', function() {
             });
             readstore.on('ready', () => {
                 expect(() => readstore.deleteEventStream('foo-bar')).to.throwError();
-                readstore.close();
                 done();
             });
         });
@@ -1166,7 +1226,6 @@ describe('EventStore', function() {
             });
             readstore.on('ready', () => {
                 expect(() => readstore.closeEventStream('foo-bar')).to.throwError();
-                readstore.close();
                 done();
             });
         });
@@ -1291,7 +1350,6 @@ describe('EventStore', function() {
                     const stream = eventstore2.getEventStream('foo-bar');
                     expect(stream).to.not.be(false);
                     expect(stream.events.length).to.be(1);
-                    eventstore2.close();
                     done();
                 });
             });
@@ -1322,7 +1380,6 @@ describe('EventStore', function() {
                         const stream = readstore.getEventStream('foo-bar');
                         expect(stream).to.not.be(false);
                         expect(stream.events.length).to.be(1);
-                        readstore.close();
                         done();
                     });
 
@@ -1512,8 +1569,6 @@ describe('EventStore', function() {
             });
             readOnly.on('ready', () => {
                 expect(() => readOnly.preCommit(() => {})).to.throwError();
-                readOnly.close();
-                eventstore = null;
                 done();
             });
         });
@@ -1583,8 +1638,6 @@ describe('EventStore', function() {
             });
             readOnly.on('ready', () => {
                 expect(() => readOnly.on('preCommit', () => {})).to.throwError();
-                readOnly.close();
-                eventstore = null;
                 done();
             });
         });
@@ -1645,8 +1698,6 @@ describe('EventStore', function() {
                 const stream = readOnly.getEventStream('foo');
                 Array.from(stream);
                 expect(calls).to.have.length(1);
-                readOnly.close();
-                eventstore = null;
                 done();
             });
         });

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -1272,6 +1272,8 @@ describe('Storage', function() {
         });
 
         it('delivers runtime appends to many new partitions without crashing', function(done){
+            const RACE_CONDITION_WRITES = 100;
+            const RACE_CONDITION_TIMEOUT_MS = 5000;
             storage = createStorage({
                 syncOnFlush: true,
                 indexOptions: { flushDelay: 1 },
@@ -1279,15 +1281,13 @@ describe('Storage', function() {
             });
             storage.open();
 
-            const writes = 100;
-            const timeoutMs = 5000;
             let received = 0;
             const timer = setTimeout(() => {
                 reader.close();
-                done(new Error(`Timeout while waiting for ${writes} appends, got ${received}`));
-            }, timeoutMs);
+                done(new Error(`Timeout while waiting for ${RACE_CONDITION_WRITES} appends, got ${received}`));
+            }, RACE_CONDITION_TIMEOUT_MS);
 
-            const reader = createReader();
+            let reader = createReader();
             reader.open();
             reader.on('error', (error) => {
                 clearTimeout(timer);
@@ -1298,14 +1298,14 @@ describe('Storage', function() {
                 received++;
                 expect(doc).to.eql({ foo: entry.number, type: `p-${entry.number}` });
                 expect(reader.partitions.has(entry.partition)).to.be(true);
-                if (received === writes) {
+                if (received === RACE_CONDITION_WRITES) {
                     clearTimeout(timer);
                     reader.close();
                     done();
                 }
             });
 
-            for (let i = 1; i <= writes; i++) {
+            for (let i = 1; i <= RACE_CONDITION_WRITES; i++) {
                 storage.write({ foo: i, type: `p-${i}` });
             }
             storage.flush();

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -1280,11 +1280,12 @@ describe('Storage', function() {
             storage.open();
 
             const writes = 100;
+            const timeoutMs = 5000;
             let received = 0;
             const timer = setTimeout(() => {
                 reader.close();
                 done(new Error(`Timeout while waiting for ${writes} appends, got ${received}`));
-            }, 5000);
+            }, timeoutMs);
 
             const reader = createReader();
             reader.open();

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -1271,6 +1271,56 @@ describe('Storage', function() {
             storage.flush();
         });
 
+        it('delivers a runtime append into a not-yet-registered partition without crashing', function(done){
+            // Reproduces the race where the index 'append' watch event arrives before the
+            // partition-creation watch event has registered the new partition. We simulate the
+            // pending partition-creation event by disabling the storage-file watch path, forcing
+            // the index-append path to register the partition on demand.
+            storage = createStorage({ syncOnFlush: true, partitioner: (document) => document.type });
+            storage.open();
+
+            let reader = createReader();
+            reader.onStorageFileChanged = () => {};
+            reader.open();
+            reader.on('wrote', (doc, entry, position) => {
+                expect(doc).to.eql({ foo: 1, type: 'one' });
+                expect(reader.partitions.has(entry.partition)).to.be(true);
+                reader.close();
+                done();
+            });
+
+            storage.write({ foo: 1, type: 'one' });
+            storage.flush();
+        });
+
+        it('retries an appended entry whose partition is not registered yet', function(done){
+            // The partition file may not be observable on disk at the exact moment the index
+            // 'append' fires (writer still flushing). The reader must re-process the entry on a
+            // later tick instead of dropping it or crashing.
+            storage = createStorage({ syncOnFlush: true });
+            storage.open();
+
+            let reader = createReader();
+            reader.open();
+
+            let attempts = 0;
+            const realEnsure = reader.ensurePartitionRegistered.bind(reader);
+            reader.ensurePartitionRegistered = (id) => {
+                attempts++;
+                return attempts > 1 && realEnsure(id);
+            };
+
+            reader.on('wrote', (doc) => {
+                expect(doc).to.eql({ foo: 1 });
+                expect(attempts).to.be.greaterThan(1);
+                reader.close();
+                done();
+            });
+
+            storage.write({ foo: 1 });
+            storage.flush();
+        });
+
         it('updates secondary indexes when writer appends', function(done){
             storage = createStorage({ syncOnFlush: true });
             storage.open();

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -1479,6 +1479,28 @@ describe('Storage', function() {
             }, 5);
         });
 
+        it('delivers a runtime append into a not-yet-registered partition without crashing', function(done){
+            // Reproduces the race where the index 'append' watch event arrives before the
+            // partition-creation watch event has registered the new partition. We simulate the
+            // pending partition-creation event by disabling the storage-file watch path, forcing
+            // the index-append path to register the partition on demand.
+            storage = createStorage({ syncOnFlush: true, partitioner: (document) => document.type });
+            storage.open();
+
+            let reader = createReader();
+            reader.onStorageFileChanged = () => {};
+            reader.open();
+            reader.on('wrote', (doc, entry, position) => {
+                expect(doc).to.eql({ foo: 1, type: 'one' });
+                expect(reader.partitions.has(entry.partition)).to.be(true);
+                reader.close();
+                done();
+            });
+
+            storage.write({ foo: 1, type: 'one' });
+            storage.flush();
+        });
+
         it('can be opened and closed multiple times', function(){
             storage = createStorage();
             storage.open();

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -1271,54 +1271,43 @@ describe('Storage', function() {
             storage.flush();
         });
 
-        it('delivers a runtime append into a not-yet-registered partition without crashing', function(done){
-            // Reproduces the race where the index 'append' watch event arrives before the
-            // partition-creation watch event has registered the new partition. We simulate the
-            // pending partition-creation event by disabling the storage-file watch path, forcing
-            // the index-append path to register the partition on demand.
-            storage = createStorage({ syncOnFlush: true, partitioner: (document) => document.type });
+        it('delivers runtime appends to many new partitions without crashing', function(done){
+            storage = createStorage({
+                syncOnFlush: true,
+                indexOptions: { flushDelay: 0 },
+                partitioner: (document) => document.type
+            });
             storage.open();
 
-            let reader = createReader();
-            reader.onStorageFileChanged = () => {};
+            const writes = 100;
+            let received = 0;
+            const timer = setTimeout(() => {
+                reader.close();
+                done(new Error(`Timeout while waiting for ${writes} appends, got ${received}`));
+            }, 5000);
+
+            const reader = createReader();
             reader.open();
-            reader.on('wrote', (doc, entry, position) => {
-                expect(doc).to.eql({ foo: 1, type: 'one' });
+            reader.on('error', (error) => {
+                clearTimeout(timer);
+                reader.close();
+                done(error);
+            });
+            reader.on('wrote', (doc, entry) => {
+                received++;
+                expect(doc).to.eql({ foo: entry.number, type: `p-${entry.number}` });
                 expect(reader.partitions.has(entry.partition)).to.be(true);
-                reader.close();
-                done();
+                if (received === writes) {
+                    clearTimeout(timer);
+                    reader.close();
+                    done();
+                }
             });
 
-            storage.write({ foo: 1, type: 'one' });
-            storage.flush();
-        });
-
-        it('retries an appended entry whose partition is not registered yet', function(done){
-            // The partition file may not be observable on disk at the exact moment the index
-            // 'append' fires (writer still flushing). The reader must re-process the entry on a
-            // later tick instead of dropping it or crashing.
-            storage = createStorage({ syncOnFlush: true });
-            storage.open();
-
-            let reader = createReader();
-            reader.open();
-
-            let attempts = 0;
-            const realEnsure = reader.ensurePartitionRegistered.bind(reader);
-            reader.ensurePartitionRegistered = (id) => {
-                attempts++;
-                return attempts > 1 && realEnsure(id);
-            };
-
-            reader.on('wrote', (doc) => {
-                expect(doc).to.eql({ foo: 1 });
-                expect(attempts).to.be.greaterThan(1);
-                reader.close();
-                done();
-            });
-
-            storage.write({ foo: 1 });
-            storage.flush();
+            for (let i = 1; i <= writes; i++) {
+                storage.write({ foo: i, type: `p-${i}` });
+                storage.flush();
+            }
         });
 
         it('updates secondary indexes when writer appends', function(done){

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect.js';
 import fs from 'fs-extra';
 import path from 'path';
 import Storage, { ReadOnly as ReadOnlyStorage, StorageLockedError, LOCK_RECLAIM } from '../src/Storage.js';
-import { matches } from '../src/Storage/ReadableStorage.js';
+import { matches } from '../src/utils/metadataUtil.js';
 import Index from '../src/Index.js';
 import zlib from 'zlib';
 //import lz4 from 'lz4';
@@ -1272,8 +1272,9 @@ describe('Storage', function() {
         });
 
         it('delivers runtime appends to many new partitions without crashing', function(done){
-            const RACE_CONDITION_WRITES = 400;
-            const RACE_CONDITION_TIMEOUT_MS = 10000;
+            // on Windows a long write streak can lead to losing file watch events, so we check for robustness against that
+            const RACE_CONDITION_WRITES = 100;
+            const RACE_CONDITION_TIMEOUT_MS = 1800;
             storage = createStorage({
                 syncOnFlush: true,
                 indexOptions: { flushDelay: 0 },

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -1272,11 +1272,11 @@ describe('Storage', function() {
         });
 
         it('delivers runtime appends to many new partitions without crashing', function(done){
-            const RACE_CONDITION_WRITES = 100;
-            const RACE_CONDITION_TIMEOUT_MS = 5000;
+            const RACE_CONDITION_WRITES = 400;
+            const RACE_CONDITION_TIMEOUT_MS = 10000;
             storage = createStorage({
                 syncOnFlush: true,
-                indexOptions: { flushDelay: 1 },
+                indexOptions: { flushDelay: 0 },
                 partitioner: (document) => document.type
             });
             storage.open();

--- a/test/Storage.spec.js
+++ b/test/Storage.spec.js
@@ -1274,7 +1274,7 @@ describe('Storage', function() {
         it('delivers runtime appends to many new partitions without crashing', function(done){
             storage = createStorage({
                 syncOnFlush: true,
-                indexOptions: { flushDelay: 0 },
+                indexOptions: { flushDelay: 1 },
                 partitioner: (document) => document.type
             });
             storage.open();
@@ -1306,8 +1306,8 @@ describe('Storage', function() {
 
             for (let i = 1; i <= writes; i++) {
                 storage.write({ foo: i, type: `p-${i}` });
-                storage.flush();
             }
+            storage.flush();
         });
 
         it('updates secondary indexes when writer appends', function(done){

--- a/test/Watcher.spec.js
+++ b/test/Watcher.spec.js
@@ -37,7 +37,7 @@ describe('Watcher', function() {
     it('is singleton per directory', function(){
         const watcher1 = createWatcher('');
         const watcher2 = createWatcher('');
-        expect(watcher1.watcher).to.equal(watcher2.watcher);
+        expect(watcher1.watchers[0]).to.equal(watcher2.watchers[0]);
     });
 
     it('can be closed multiple times safely', function(){

--- a/test/Watcher.spec.js
+++ b/test/Watcher.spec.js
@@ -37,7 +37,7 @@ describe('Watcher', function() {
     it('is singleton per directory', function(){
         const watcher1 = createWatcher('');
         const watcher2 = createWatcher('');
-        expect(watcher1.watchers[0]).to.equal(watcher2.watchers[0]);
+        expect(watcher1.watcher).to.equal(watcher2.watcher);
     });
 
     it('can be closed multiple times safely', function(){

--- a/test/Watcher.spec.js
+++ b/test/Watcher.spec.js
@@ -78,14 +78,24 @@ describe('Watcher', function() {
         let fd = fs.openSync(dataDirectory + '/.file', 'w');
         fs.closeSync(fd);
         const watcher = createWatcher('');
-        let count = 0;
+        let finished = false;
+        const seen = new Set();
+        const finish = (error) => {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            done(error);
+        };
         watcher.on('rename', (filename) => {
-            count++;
-            if (count === 1) {
-                expect(filename).to.be('.file');
-            } else if (count === 2) {
-                expect(filename).to.be('.file2');
-                done();
+            try {
+                expect(filename === '.file' || filename === '.file2').to.be(true);
+                seen.add(filename);
+                if (seen.has('.file') && seen.has('.file2')) {
+                    finish();
+                }
+            } catch (error) {
+                finish(error);
             }
         });
         fs.renameSync(dataDirectory + '/.file', dataDirectory + '/.file2');


### PR DESCRIPTION
When a read-only storage with an active file watcher receives an index 'append' event, it could crash with "Partition #N does not exist." if the partition-creation watch event had not yet been dispatched. The index and partition files are watched independently, so the append can arrive first.

Changes:
- src/utils/fsUtil.js: add scanForFilesSync for synchronous on-demand partition discovery on the cold lazy-registration path.
- src/Storage/ReadOnlyStorage.js:
  - Extract registerPartitionFile() shared by both watch paths.
  - Add ensurePartitionRegistered() which synchronously scans the data directory to register any missing partition before reading from it (the writer always flushes the partition before appending to the index, so the file already exists on disk at this point).
  - Replace the inline append loop with processAppendedEntries() / scheduleAppendRetry() / emitAppendedEntry(): if the partition is still not found after the sync scan, the remaining entries are re-scheduled on the next tick instead of throwing out of EventEmitter.emit(); a read failure is surfaced as an 'error' event rather than an uncaught exception.
- test/Storage.spec.js: replace the prior hook-based regression checks with a minimal end-to-end repro that does not override internal callbacks: use `indexOptions.flushDelay: 0` and 400 writes to distinct new partitions in a loop, then assert all runtime appends are delivered without crashing.