### PR TITLE
Add support for algebraic stream joins

### DIFF
--- a/concepts/2026-06-25-logical-streams-api.md
+++ b/concepts/2026-06-25-logical-streams-api.md
@@ -1,0 +1,125 @@
+# Logical Stream Selector API
+
+Provide logical `AND`/`OR` composition over streams without introducing a separate query language.
+
+## Core Direction
+
+Use **one** stream composition API:
+
+- `fromStreams(selector, options)` is the canonical entry point.
+- `AND` use cases are represented directly in selector algebra.
+- `CombinedEventStream` is removed; `JoinEventStream` is the single implementation behind `fromStreams`.
+
+## Selector Algebra
+
+Nested arrays encode alternating operators by depth:
+
+- depth 0: `OR`
+- depth 1: `AND`
+- depth 2: `OR`
+- depth 3: `AND`
+- ...
+
+Examples:
+
+```javascript
+fromStreams(['a', 'b']);
+// a OR b
+
+fromStreams([['a', 'b']]);
+// a AND b
+
+fromStreams([
+  ['tag1', 'tag2', ['typeA', 'typeB']],
+  ['tag3', 'tag4']
+]);
+// (tag1 AND tag2 AND (typeA OR typeB)) OR (tag3 AND tag4)
+```
+
+## Convenience Helpers
+
+`anyOf` / `allOf` / `all` helpers improve readability and normalize shape artifacts.
+
+Canonical style:
+
+```javascript
+anyOf(allOf('a', 'b'), 'c');
+```
+
+Normalization examples:
+
+- `anyOf(anyOf('a', 'b'), 'c')` -> `anyOf('a', 'b', 'c')`
+- `allOf(allOf('a', 'b'), 'c')` -> `allOf('a', 'b', 'c')`
+- `OR(..., all(), ...)` -> `all()`
+- `AND(..., all(), ...)` -> remove `all()` from that `AND` level
+
+## Implementation via Index Union/Intersect
+
+Selector evaluation maps directly to index set operations.
+
+- `OR` level -> `union(...)`
+- `AND` level -> `intersect(...)`
+
+Example:
+
+```javascript
+[
+  ['a', 'b', ['c', 'd']],
+  ['e', 'f']
+]
+// (a AND b AND (c OR d)) OR (e AND f)
+```
+
+Execution:
+
+1. Evaluate depth 2 (`OR`) subtree:
+   - `x = union(index(c), index(d))`
+2. Evaluate each depth 1 (`AND`) group:
+   - `g1 = intersect(index(a), index(b), x)`
+   - `g2 = intersect(index(e), index(f))`
+3. Evaluate depth 0 (`OR`) root:
+   - `result = union(g1, g2)`
+
+General recursion:
+
+```text
+evaluate(node, depth):
+  if node is streamName:
+    return index(streamName)
+
+  children = node.map(child => evaluate(child, depth + 1))
+
+  if depth is even:  // OR level
+    return union(children)
+
+  // depth is odd: AND level
+  return intersect(children)
+```
+
+## Execution Notes
+
+- `fromStreams(['a', 'b'])` maps to existing OR/union paths naturally.
+- For commit conflict checks, existence checks can short-circuit; full ordering is not required.
+
+## Join Replacement Status
+
+The previous `JoinEventStream` k-way-merge logic is fully replaced by selector-algebra evaluation over indexes (`union`/`intersect`) in the canonical `JoinEventStream` implementation.
+
+Benchmark excerpt (`bench/bench-join-vs-combined-or.js`, 2026-06-27, selected cases):
+
+```text
+Scenario: balanced-with-two-noise-streams, forward-full
+JoinEventStream [a,b] 34 ops/s | Combined OR [a,b] 36 ops/s | relative Join/Combined: 0.94x
+
+Scenario: b-sparse-with-noise, forward-full
+JoinEventStream [a,b] 54 ops/s | Combined OR [a,b] 55 ops/s | relative Join/Combined: 0.98x
+
+Scenario: bursty-b, reverse-max-capped-75pct
+JoinEventStream [a,b] 75 ops/s | Combined OR [a,b] 73 ops/s | relative Join/Combined: 1.03x
+```
+
+Interpretation: results are in near-parity with small scenario-dependent variation. Together with the cleaner single-path architecture, this supports keeping the algebra-based implementation as the only stream-composition path.
+
+## Migration Note
+
+- Existing "all streams must match" use cases are represented with selector algebra (for example `allOf(...)` or equivalent normalized array form).

--- a/concepts/2026-06-27-dcb-query-compatibility-concept.md
+++ b/concepts/2026-06-27-dcb-query-compatibility-concept.md
@@ -1,0 +1,254 @@
+# DCB Query Compatibility Concept
+
+This document builds on `concepts/2026-06-25-logical-streams-api.md` and defines DCB compatibility on top of the generic stream-selector model.
+
+## Goal
+
+Keep the EventStore core API stream-based while enabling DCB use cases through a dedicated translation layer.
+
+- EventStore operates on stream selectors (`OR`/`AND` algebra over stream names).
+- DCB query semantics (`types` + `tags`) are compiled to stream selectors.
+- `query()` returns `{ stream, condition }` and stays the single entry point.
+- `fromStreams` + `JoinEventStream` are the only stream-composition surface; no separate `CombinedEventStream` API remains.
+
+## Non-goals
+
+- No wire protocol format.
+- No storage layout details.
+- No requirement that DCB semantics become part of the generic stream API.
+
+## Core Principle
+
+The generic API does **not** know about `types`/`tags` as first-class concepts. It only evaluates selector algebra over stream names.
+
+DCB support is an opt-in layer that:
+
+1. validates/normalizes DCB query objects,
+2. resolves `types`/`tags` to concrete stream names,
+3. compiles them into selector algebra,
+4. delegates execution to the generic selector path.
+
+## Query Model (DCB Layer Input)
+
+```ts
+export type EventType = string;
+export type EventTag = string;
+
+export interface QueryItem {
+  /** OR within one item */
+  types?: readonly EventType[];
+  /** AND within one item */
+  tags?: readonly EventTag[];
+}
+
+export type QueryMatcher =
+  | ((payload: any, metadata: any) => boolean)
+  | object;
+
+export interface Query {
+  /** OR across items. Empty means match all. */
+  items: readonly QueryItem[];
+  matcher?: QueryMatcher | null;
+}
+```
+
+## Unified API Surface
+
+```ts
+export interface QueryOptions {
+  minRevision?: number; // default 1
+  maxRevision?: number; // default -1
+  raw?: boolean; // default false
+  matcher?: QueryMatcher | null;
+}
+
+export interface DcbQueryResult {
+  stream: EventStreamLike;
+  condition: CommitCondition;
+}
+
+export interface EventStore {
+  /** Generic selector execution API */
+  fromStreams(selector: readonly unknown[], options?: QueryOptions): EventStreamLike;
+
+  /** Unified query API: selector array OR DCB query object */
+  query(selectorOrQuery: readonly unknown[] | Query, options?: QueryOptions): DcbQueryResult;
+}
+```
+
+Notes:
+
+- `queryByDefinition` / `queryItems` / `queryAll` are removed from the concept.
+- Moving from multi-arg query signatures to `options` object is considered part of one breaking change.
+
+## Selector Algebra
+
+`fromStreams` evaluates nested selectors with alternating operators by depth:
+
+- depth 0: `OR`
+- depth 1: `AND`
+- depth 2: `OR`
+- ...
+
+`all()` is a selector helper term with normalization:
+
+- `OR(..., all(), ...)` -> `all()`
+- `AND(..., all(), ...)` -> remove `all()` from that `AND` level
+
+This allows `AND` queries without introducing an additional stream-composition method.
+
+## Mapping DCB Query -> Selector
+
+Per item:
+
+- `types` become one `OR` term
+- `tags` become `AND` terms
+
+Example:
+
+- `{ types: [A, B], tags: [T1, T2] }`
+- compiles to `allOf(T1, T2, anyOf(A, B))`
+
+Query-level:
+
+- `items = [i1, i2, ...]` compiles to `anyOf(i1Selector, i2Selector, ...)`
+- `items = []` compiles to `all()`
+
+## anyOf/allOf Helper API
+
+Helpers are syntax sugar over selector arrays and normalize accidental nesting.
+
+```ts
+type SelectorTerm = string | readonly SelectorTerm[];
+
+export interface SelectorApi {
+  anyOf(...terms: readonly SelectorTerm[]): SelectorTerm;
+  allOf(...terms: readonly SelectorTerm[]): SelectorTerm;
+  all(): SelectorTerm;
+}
+```
+
+Canonical readable style:
+
+- `anyOf(allOf(a, b), c)`
+
+Normalization examples:
+
+- `anyOf(anyOf(a, b), c)` -> `anyOf(a, b, c)`
+- `allOf(allOf(a, b), c)` -> `allOf(a, b, c)`
+- redundant single-child wrappers collapse
+
+## CommitCondition Integration
+
+`selector` remains the property name for now (rename can happen in a later breaking release).
+
+```ts
+export interface CommitCondition {
+  readonly noneMatchAfter: number;
+  readonly raw?: boolean;
+  readonly selector?: {
+    /** Already normalized selector in execution order. */
+    readonly streams: readonly unknown[];
+    readonly matcher?: QueryMatcher | null;
+    readonly optimization?: {
+      readonly plannedAtStoreLength?: number;
+      readonly andOrderByEstimatedCost?: readonly number[];
+    };
+  };
+}
+```
+
+Minimal payload guidance:
+
+- Transport only what commit check needs: `noneMatchAfter`, `raw`, `selector.streams`, `matcher`, optional light `optimization`.
+- Do not duplicate selector/matcher in nested plan objects.
+- The caller already has the original `Query` object; it does not need to be embedded in condition metadata.
+
+## Compiled Plan Shape (Internal/Optional)
+
+A plan can exist internally, but is not required in serialized condition payload.
+
+```ts
+export interface CompiledItemPlan {
+  readonly itemSelector: readonly unknown[];
+}
+
+export interface CompiledQueryPlan {
+  readonly isAll: boolean;
+  readonly selector: readonly unknown[];
+  readonly optimization?: {
+    readonly plannedAtStoreLength: number;
+    readonly andOrderByEstimatedCost?: readonly number[];
+  };
+}
+```
+
+`itemOrderByEstimatedCost` is not part of the stable public transport contract.
+
+## DCB Index Opt-In
+
+DCB querying requires dedicated index streams and should be explicitly enabled.
+
+- `typeAccessor`: enables type stream indexing (existing path).
+- `tagsAccessor`: enables tag stream indexing.
+- Supported configurations: either accessor alone, or both together.
+
+Practical expectation:
+
+- `tagsAccessor` alone is possible but usually weak for real DCB decision models.
+- Most practical DCB usage is type-scoped with tags as additional narrowing.
+
+## Execution Semantics
+
+Given `condition.noneMatchAfter`:
+
+- conflict check runs on `(noneMatchAfter + 1 .. latest)` only,
+- conflict exists if any new event matches selector + matcher,
+- for pure type-stream `OR` checks, conflict detection is existence-based with early exit (no global merge/sort required).
+
+## Example
+
+```js
+const input = {
+  items: [
+    { types: ['EventType1', 'EventType2'], tags: ['tag1', 'tag2'] },
+    { tags: ['tag3', 'tag4'] },
+    { types: ['EventType3'] }
+  ],
+  matcher: { payload: { tenantId: 't-42' } }
+};
+
+const { stream, condition } = eventstore.query(input, { minRevision: 1 });
+```
+
+Equivalent selector intent:
+
+```js
+anyOf(
+  allOf('tag1', 'tag2', anyOf('EventType1', 'EventType2')),
+  allOf('tag3', 'tag4'),
+  allOf(anyOf('EventType3'))
+);
+```
+
+## Rollout Plan
+
+1. Keep one selector algebra in `fromStreams`.
+2. Move `query()` to unified signature: `query(selector|Query, options)`.
+3. Add DCB compiler layer (`types`/`tags` -> selector) with accessor opt-in.
+4. Add `anyOf`/`allOf`/`all()` normalization helpers.
+5. Keep `CommitCondition` payload minimal and de-duplicated.
+6. Add conformance tests:
+   - OR over items
+   - OR over item types
+   - AND over item tags
+   - helper normalization
+   - `items = []` equals `all()`
+   - commit conflict check equivalence vs query semantics
+
+## Open Decisions
+
+1. Exact tag stream naming (`tag:<value>` vs namespaced variants).
+2. Strict vs forgiving normalization for malformed nested selector arrays.
+3. Whether function matchers are serializable or only object matchers.
+4. Whether to keep a temporary compatibility shim for old query signature during migration.

--- a/docs/api.md
+++ b/docs/api.md
@@ -240,12 +240,21 @@ Remove a previously registered listener.
 eventstore.fromStreams(streamName, streamNames [, minRevision [, maxRevision [, predicate [, raw]]]]) → EventStream
 ```
 
-Create a virtual `EventStream` by joining the listed streams in sequence-number order.
+Create a virtual stream from selected streams.
+
+- Selector arrays are evaluated with alternating operators by depth:
+  - depth 0: `OR`
+  - depth 1: `AND`
+  - depth 2: `OR`
+  - ...
+- `['a', 'b']` means `a OR b`.
+- `[['a', 'b']]` means `a AND b`.
+- `[['tag1', 'tag2', ['typeA', 'typeB']], ['tag3', 'tag4']]` means `(tag1 AND tag2 AND (typeA OR typeB)) OR (tag3 AND tag4)`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `streamName` | `string` | Transient name for the joined stream. |
-| `streamNames` | `Array<string>` | Names of the streams to join. |
+| `streamName` | `string` | Transient name for the resulting virtual stream. |
+| `streamNames` | `Array<string\|Array>` | Stream selector tree (strings as leaves, arrays as nested groups). |
 
 Throws if any named stream does not exist.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ This page describes the technical implementation and architecture of the `node-e
 |------------------|------|
 | `EventStore.js` | Public API facade — manages streams, commits, consumers, and concurrency |
 | `EventStream.js` | Iterable / Node.js Readable wrapper around a positional index |
-| `JoinEventStream.js` | Merges several `EventStream` instances into one globally-ordered stream |
+| `JoinEventStream.js` | Evaluates nested stream selectors (alternating OR/AND by depth) into one globally-ordered virtual stream |
 | `Consumer.js` | Durable event consumer with at-least-once / exactly-once delivery semantics |
 | `Watcher.js` | Reference-counting singleton that watches a directory for file-system changes |
 | `WatchesFile.js` | Mixin that wires a file to a `Watcher` instance and re-reads it on change |
@@ -106,7 +106,7 @@ graph TD
 
 ### JoinEventStream
 
-`JoinEventStream` merges several `EventStream` instances into a single globally-ordered stream by always yielding the event with the lowest sequence number across all inputs — a k-way merge. Used to build category streams and cross-aggregate projections.
+`JoinEventStream` evaluates a selector tree over stream indexes and produces one globally-ordered virtual stream. Selector levels alternate by depth (`OR` at depth 0, `AND` at depth 1, then `OR`, ...), using index set operations (`union`/`intersect`) before reading documents. Used by `EventStore.fromStreams()` for cross-stream and DCB-compiled selector queries.
 
 ### Consumer
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+- Extended `JoinEventStream` with nested selector-algebra composition (`OR` at depth 0, `AND` at depth 1, then alternating), available through `fromStreams`.
+- Updated DCB documentation to describe `types`/`tags` semantics with optional tag-stream indexing and matcher-only execution trade-offs.
+
 ## 1.3.4
 
 - Fix edge case in JoinStream when range not inside selected streams

--- a/docs/dcb.md
+++ b/docs/dcb.md
@@ -99,9 +99,12 @@ const store = new EventStore('my-store', {
 
 Type stream names currently map directly to event types (for example `CourseCreated`), without a `type:` prefix.
 
-When configured, `query()` treats a missing type stream as empty rather than throwing — a type that has never been committed yet is simply an empty result.
+`query()` treats missing referenced streams as empty sets. This applies both to type-stream lists and nested selector algebra.
 
-> **Without `typeAccessor`**, `query()` throws if a listed type stream does not exist. You must create it first with `createEventStream()`, or use type-named entity streams (e.g. `commit('OrderPlaced', ...)`).
+In selector terms:
+
+- missing stream in an `OR` group: no effect,
+- missing stream in an `AND` group: that branch becomes empty.
 
 > **New stores only**: type indexes are built with `reindex=false` — they only cover events committed *after* the index was first created. Always configure `typeAccessor` from the beginning if you intend to use `query()`.
 
@@ -168,6 +171,25 @@ Equivalent selector intent (when tags are represented as streams):
 - per-item `tags`: `AND`
 - per-item `types`: `OR`
 
+With tag streams materialized, the same DCB intent can now be passed directly to `query()` as nested selector algebra:
+
+```javascript
+const courseId = 'course:jdsj4';
+const studentId = 'student:gfh3j';
+
+const { stream, condition } = store.query([
+    [courseId, ['CourseCreated', 'CourseCapacityChanged', 'StudentSubscribedToCourse']],
+    [studentId, ['StudentCreated', 'StudentSubscribedToCourse']]
+]);
+```
+
+This selector uses the same alternating semantics as `fromStreams(...)` / `JoinEventStream`:
+
+- top level array: `OR` across query items,
+- second level arrays: `AND` (tag stream + type-group stream),
+- third level arrays: `OR` across event types.
+
+Alternative syntax for the same selector intent is:
 ```javascript
 anyOf(
     allOf('course:jdsj4', anyOf('CourseCreated', 'CourseCapacityChanged', 'StudentSubscribedToCourse')),
@@ -175,7 +197,9 @@ anyOf(
 );
 ```
 
-In node-event-storage, this can be expressed without tag streams by using the `matcher` function. Pass the union of all types, and encode per-item tag logic in the matcher:
+`anyOf`/`allOf` above describe selector intent and are not runtime helpers in this package.
+
+In node-event-storage, this can also be expressed without tag streams by using the `matcher` function. Pass the union of all types, and encode per-item tag logic in the matcher:
 
 ```javascript
 const courseId  = 'course:jdsj4';
@@ -203,6 +227,44 @@ Rule of thumb:
 
 - higher write load / lower read selectivity pressure -> matcher-only is often better,
 - lower write load / high tag diversity with many matcher misses -> tag streams are often better.
+
+### Benchmark findings and practical recommendation
+
+This benchmark section is inspired by the excellent pyeventsourcing speedrun style: a compact scenario that makes architectural trade-offs visible under sustained write-then-read pressure.
+
+Benchmark setup in this repository:
+
+- scenario: course subscriptions with DCB read model rebuilding,
+- runtime: 3 seconds per mode,
+- per iteration: 10 student registrations, 10 course registrations, 100 enrollments (120 operations total),
+- each mode runs against a fresh data directory.
+
+Recent measurements with that setup produced the following excerpt:
+
+| Mode                    | Ops/s | us/op | Relative vs matcher-only |
+|-------------------------|------:|------:|-------------------------:|
+| Matcher-only            |   372 |  2690 |                    1.00x |
+| Tag-streams             |  1241 |   806 |                    3.34x |
+| Semester-bounded stream |  3606 |   277 |                    9.69x |
+
+Mode definitions and how to apply them in practice:
+
+- **Matcher-only**: query by event types and evaluate tags only via matcher logic at read time. Practical setup: keep type streams, avoid tag streams, call `query(types, matcher)`.
+- **Tag-streams**: materialize tags as dedicated streams and build DCB context from stream selectors. Practical setup: create tag streams (manually or in pre-commit) and query through `fromStreams(...)` joins.
+- **Semester-bounded stream**: write all decision-relevant events for a semester into `semesters/{id}` so the read context stays naturally bounded. Practical setup: choose business-bounded write streams first, then query only within that boundary.
+
+This demonstrates three important points:
+
+- pure matcher-only DCB can degrade when the scanned context grows without a hard domain boundary,
+- DCB according to the full types+tags specification is usually fast enough with tag streams, but this can create many streams and extra index writes,
+- the best long-term approach is often domain partitioning (bounded write streams), so reads are naturally selective even without additional tag/type streams.
+
+Compared to generic SQL-backed event-store speedruns (including the pyeventsourcing benchmark context), this indicates that event-storage can outperform when stream boundaries reflect real domain limits, not only technical entity ownership.
+
+For the semester case specifically, realistic systems typically need one more filter/intersection for enrollment-relevant types because a semester stream may contain many unrelated events. Two common options are:
+
+- keep one semester stream and intersect with enrollment-related event types during context read,
+- split into `semester/{id}/students`, `semester/{id}/courses`, and `semester/{id}/enrolments`, then build the DCB context from the join of those three streams.
 
 Future direction:
 

--- a/docs/dcb.md
+++ b/docs/dcb.md
@@ -40,6 +40,14 @@ That `matcher` can be either a predicate function or the same object-matcher syn
 
 `query()` also supports raw mode (`query(types, matcher, minRevision, true)`), but raw streaming itself is a general stream-reading feature, not DCB-specific. See [Event Streams -> Reading Streams](streams.md#reading-streams) for the full raw-mode semantics and matcher behavior.
 
+### Implementation detail: selector algebra when tags are indexed as streams
+
+The important DCB concept is `types` + `tags` selection semantics. How this is executed is an implementation detail.
+
+If tags are materialized as dedicated streams, DCB items naturally compile to `fromStreams` selector algebra (`OR` across items, `AND` across item tags, `OR` across item types).
+
+If tags are not materialized as streams, the same semantics can be expressed entirely through matcher logic.
+
 ### Step 2 — Build the decision model
 
 ```javascript
@@ -89,11 +97,15 @@ const store = new EventStore('my-store', {
 
 `typeAccessor` accepts a dot-notation path string (e.g. `'type'`, `'meta.kind'`) pointing to the event type field, which also enables faster index routing. For non-standard event layouts a function `(event) => string` can be used instead.
 
+Type stream names currently map directly to event types (for example `CourseCreated`), without a `type:` prefix.
+
 When configured, `query()` treats a missing type stream as empty rather than throwing — a type that has never been committed yet is simply an empty result.
 
 > **Without `typeAccessor`**, `query()` throws if a listed type stream does not exist. You must create it first with `createEventStream()`, or use type-named entity streams (e.g. `commit('OrderPlaced', ...)`).
 
 > **New stores only**: type indexes are built with `reindex=false` — they only cover events committed *after* the index was first created. Always configure `typeAccessor` from the beginning if you intend to use `query()`.
+
+Tag streams are optional. DCB queries can be implemented without any tag streams by using matcher logic only.
 
 ---
 
@@ -150,7 +162,20 @@ queryItems = [
 
 An event matches when **any** item matches it: the event's type must be in that item's `types` **and** the event must carry **all** of that item's tags.
 
-In node-event-storage this is expressed today using the `matcher` function. Pass the union of all types, and encode the per-item logic in the matcher:
+Equivalent selector intent (when tags are represented as streams):
+
+- query level (`items`): `OR`
+- per-item `tags`: `AND`
+- per-item `types`: `OR`
+
+```javascript
+anyOf(
+    allOf('course:jdsj4', anyOf('CourseCreated', 'CourseCapacityChanged', 'StudentSubscribedToCourse')),
+    allOf('student:gfh3j', anyOf('StudentCreated', 'StudentSubscribedToCourse'))
+);
+```
+
+In node-event-storage, this can be expressed without tag streams by using the `matcher` function. Pass the union of all types, and encode per-item tag logic in the matcher:
 
 ```javascript
 const courseId  = 'course:jdsj4';
@@ -167,5 +192,20 @@ const { stream, condition } = store.query(
 );
 ```
 
-The type membership check in the matcher duplicates what is already expressed in the `types` array — this is a current limitation. Future versions may introduce tag-based secondary indexes and a native query-item format to remove this duplication.
+## Choosing Between Matcher-Only and Tag Streams
+
+Both approaches are valid and can coexist.
+
+- **Matcher-only**: no additional tag indexes to maintain; lower write amplification.
+- **Tag streams**: more index writes per commit (one extra index write per configured tag stream), but can reduce read-time misses and deserialization/evaluation overhead when tag cardinality is high.
+
+Rule of thumb:
+
+- higher write load / lower read selectivity pressure -> matcher-only is often better,
+- lower write load / high tag diversity with many matcher misses -> tag streams are often better.
+
+Future direction:
+
+- automatic tag-stream creation may become an optional config,
+- selective/manual creation for specific high-value tags should stay possible.
 

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -226,6 +226,27 @@ for (const event of joined) {
 }
 ```
 
+`fromStreams` accepts a selector tree with alternating operators by depth:
+
+- depth 0: `OR`
+- depth 1: `AND`
+- depth 2: `OR`
+- ...
+
+```javascript
+// OR
+eventstore.fromStreams('or-stream', ['order-42', 'order-99']);
+
+// AND
+eventstore.fromStreams('and-stream', [['order-42', 'payment-42']]);
+
+// (tag-a AND tag-b AND (type-created OR type-updated)) OR (tag-c AND tag-d)
+eventstore.fromStreams('selector-stream', [
+    ['tag-a', 'tag-b', ['type-created', 'type-updated']],
+    ['tag-c', 'tag-d']
+]);
+```
+
 The result is not persisted and cannot be used with consumers. For frequently-needed joins, create a permanent derived stream with `createStream` instead.
 
 ## Stream Categories

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -25,6 +25,17 @@ const STORAGE_HOOK_EVENTS = new Set(['preCommit', 'preRead']);
 
 class OptimisticConcurrencyError extends Error {}
 
+function assertSelectorStreamsExist(streams, streamMap) {
+    for (const node of streams) {
+        if (typeof node === 'string') {
+            assert(node in streamMap, `Stream "${node}" does not exist.`);
+            continue;
+        }
+        assert(Array.isArray(node) && node.length > 0, 'Each selector node must be a non-empty stream name array or string.');
+        assertSelectorStreamsExist(node, streamMap);
+    }
+}
+
 /**
  * An accept condition that captures the global event-log position at the time a {@link EventStore#query}
  * call was made.  Pass it as the `expectedVersion` argument to {@link EventStore#commit} to enforce
@@ -632,16 +643,18 @@ class EventStore extends events.EventEmitter {
     }
 
     /**
-     * Create a virtual event stream from existing streams by joining them.
+     * Create a virtual event stream from existing streams.
+     *
+     * Uses selector algebra with alternating operator levels (depth 0 = OR, depth 1 = AND, ...).
      *
      * @param {string} streamName The (transient) name of the joined stream.
-     * @param {Array<string>} streamNames An array of the stream names to join.
+     * @param {Array<string|Array<string>>} streamNames Stream selector input.
      * @param {number} [minRevision=1] The 1-based minimum revision to include in the events (inclusive).
      * @param {number} [maxRevision=-1] The 1-based maximum revision to include in the events (inclusive).
      * @param {function|object|null} [predicate] Optional matcher (see {@link EventStream}).
      * @param {boolean} [raw=false] If true, return NDJSON buffers.
-     * @returns {EventStream} The joined event stream.
-     * @throws {Error} if any of the streams doesn't exist.
+     * @returns {EventStream|JoinEventStream}
+     * @throws {Error} if any selected stream doesn't exist.
      */
     fromStreams(streamName, streamNames, minRevision = 1, maxRevision = -1, predicate = null, raw = false) {
         ({ predicate, raw } = normalizePredicateRaw(predicate, raw));
@@ -651,10 +664,7 @@ class EventStore extends events.EventEmitter {
             return new EventStream(streamName, this);
         }
 
-        for (let stream of streamNames) {
-            assert(stream in this.streams, `Stream "${stream}" does not exist.`);
-        }
-
+        assertSelectorStreamsExist(streamNames, this.streams);
         return new JoinEventStream(streamName, streamNames, this, minRevision, maxRevision, predicate, raw);
     }
 

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -1,97 +1,179 @@
 import EventStream from './EventStream.js';
-import { assert, kWayMerge } from './utils/util.js';
+import { assert, iterate } from './utils/util.js';
+import { union, intersect } from './utils/indexUtil.js';
 import { normalizeRevision } from './utils/apiHelpers.js';
 
-/** Reusable sentinel used for missing or empty per-stream iterators. */
-const emptyIterator = Object.freeze({ next() { return { done: true }; } });
-
 /**
- * An event stream is a simple wrapper around an iterator over storage documents.
- * It implements a node readable stream interface.
+ * JoinEventStream is a virtual stream over one or multiple physical stream indexes.
+ *
+ * It is the canonical implementation behind `EventStore.fromStreams(...)` and supports
+ * nested selector algebra with alternating operators by depth:
+ *
+ * - depth 0 (top-level array): OR
+ * - depth 1: AND
+ * - depth 2: OR
+ * - ... alternating by depth parity
+ *
+ * Flat arrays (e.g. `['a', 'b']`) therefore keep the legacy join semantics (OR).
+ *
+ * @extends EventStream
  */
 class JoinEventStream extends EventStream {
 
     /**
-     * @param {string} name The name of the stream.
-     * @param {Array<string>} streams The name of the streams to join together.
-     * @param {EventStore} eventStore The event store to get the stream from.
-     * @param {number} [minRevision] The 1-based minimum revision to include in the events (inclusive).
-     * @param {number} [maxRevision] The 1-based maximum revision to include in the events (inclusive).
-     * @param {function|object|null} [predicate] Optional matcher (see {@link EventStream}).
-     * @param {boolean} [raw=false] If true, emit NDJSON Buffers.
+     * @param {string} name The name of this virtual stream.
+     * @param {Array<string|Array>} selector Stream selector as flat or nested arrays.
+     * @param {EventStore} eventStore The event store instance.
+     * @param {number} [minRevision=1] Global minimum revision (inclusive).
+     * @param {number} [maxRevision=-1] Global maximum revision (inclusive).
+     * @param {function|object|null} [predicate] Optional matcher (same semantics as EventStream).
+     * @param {boolean} [raw=false] If true, emit NDJSON buffers.
      */
-    constructor(name, streams, eventStore, minRevision = 1, maxRevision = -1, predicate = null, raw = false) {
+    constructor(name, selector, eventStore, minRevision = 1, maxRevision = -1, predicate = null, raw = false) {
         super(name, eventStore, minRevision, maxRevision, predicate, raw);
-        assert(streams instanceof Array && streams.length > 0, `Invalid list of streams supplied to JoinStream ${name}.`);
+        assert(Array.isArray(selector) && selector.length > 0, `Invalid selector supplied to JoinEventStream ${name}.`);
 
+        this.eventStore = eventStore;
+        this.selector = this.normalizeSelector(selector);
         this.streamIndex = eventStore.storage.index;
-        // Translate revisions to index numbers (1-based) and wrap around negatives
         this.minRevision = normalizeRevision(minRevision, eventStore.length);
         this.maxRevision = normalizeRevision(maxRevision, eventStore.length);
-        this.fetch = function() {
-            return streams.map(streamName => {
-                const streamIndex = eventStore.streams[streamName]?.index;
-                if (!streamIndex || streamIndex.length === 0) {
-                    return emptyIterator;
-                }
-                const ascending = this.minRevision <= this.maxRevision;
-                const from = streamIndex.find(this.minRevision, ascending);
-                const until = streamIndex.find(this.maxRevision, !ascending);
-                if (
-                    from === 0 ||
-                    until === 0 ||
-                    (ascending ? from > until : from < until)
-                ) {
-                    // find() returns 0 when the requested revision is outside the stream's range
-                    // (e.g. minRevision > all entries, or maxRevision < all entries).
-                    return emptyIterator;
-                }
-                // Raw mode: get { buffer, time64, sequenceNumber } for binary-header ordering.
-                // Object mode: storage deserializes for us and we order by metadata.commitId.
-                return eventStore.storage.readRange(from, until, streamIndex, this.raw);
-            });
-        }
+        this.version = this.streamIndex.length;
+
+        this._combinedRanges = null;
+
+        this.fetch = () => this.iterateDocuments();
         this._iterator = null;
     }
 
     /**
-     * @returns {Generator<object>}
+     * Normalize selector shape to nested arrays and validate leaf types.
+     * Missing streams are allowed here to keep direct JoinEventStream construction compatible;
+     * they are treated as empty ranges.
+     *
+     * @private
+     * @param {Array<string|Array>} selector
+     * @returns {Array<string|Array>}
      */
-    createMergedIterator() {
-        const ascending = this.minRevision <= this.maxRevision;
-        const raw = this.raw;
-        return kWayMerge(
-            this.fetch(),
-            entry => raw ? entry.sequenceNumber : entry.metadata.commitId,
-            ascending
-        );
+    normalizeSelector(selector) {
+        const normalized = [];
+        for (const node of selector) {
+            if (typeof node === 'string') {
+                assert(node.length > 0, 'Stream names must be non-empty strings.');
+                normalized.push(node);
+                continue;
+            }
+
+            assert(Array.isArray(node) && node.length > 0, 'Each selector node must be a non-empty stream name array or string.');
+            normalized.push(this.normalizeSelector(node));
+        }
+        return normalized;
     }
 
     /**
-     * Returns the next event in merge order.
+     * Resolve and cache the combined index-entry ranges for the full selector.
      *
-     * In raw mode: returns `{ buffer, time64, sequenceNumber }` from the binary header — no JSON
-     * deserialization. In object mode: returns a deserialized `{ stream, payload, metadata }` document
-     * produced by the storage layer.
-     * @returns {object|false} The next event, or `false` when the stream is exhausted.
+     * @private
+     * @returns {Array<Array<number>>}
      */
-    next() {
-        if (!this._iterator) {
-            this._iterator = this.createMergedIterator();
+    resolveCombinedRanges() {
+        if (this._combinedRanges) {
+            return this._combinedRanges;
         }
-        while (true) {
-            const step = this._iterator.next();
-            if (step.done) {
-                return false;
-            }
-            const next = step.value;
 
-            if (this.matchesPredicate(next)) {
-                return next;
+        this._combinedRanges = this.resolveSelectorRanges(this.selector);
+        return this._combinedRanges;
+    }
+
+    /**
+     * Resolve one selector node into a sorted index-entry range.
+     *
+     * @private
+     * @param {string|Array<string|Array>} selectorNode
+     * @param {number} [depth=0]
+     * @returns {Array<Array<number>>}
+     */
+    resolveSelectorRanges(selectorNode, depth = 0) {
+        if (typeof selectorNode === 'string') {
+            const index = this.eventStore.streams[selectorNode]?.index;
+            return this.resolveIndexRange(index);
+        }
+
+        const childRanges = selectorNode.map(node => this.resolveSelectorRanges(node, depth + 1));
+        return depth % 2 === 0 ? union(...childRanges) : intersect(...childRanges);
+    }
+
+    /**
+     * Resolve one stream index to the global revision-bounded entry range.
+     *
+     * @private
+     * @param {object|undefined} index
+     * @returns {Array<Array<number>>}
+     */
+    resolveIndexRange(index) {
+        if (!index || index.length === 0) {
+            return [];
+        }
+
+        const ascending = this.minRevision <= this.maxRevision;
+        const from = index.find(this.minRevision, ascending);
+        const until = index.find(this.maxRevision, !ascending);
+        if (
+            from === 0 ||
+            until === 0 ||
+            (ascending ? from > until : from < until)
+        ) {
+            return [];
+        }
+
+        const rangeFrom = ascending ? from : until;
+        const rangeUntil = ascending ? until : from;
+        return index.range(rangeFrom, rangeUntil) || [];
+    }
+
+    /**
+     * Iterate matching index entries in requested direction.
+     *
+     * @private
+     * @returns {Generator<Array<number>>}
+     */
+    *iterateEntries() {
+        const entries = this.resolveCombinedRanges();
+        const forwards = this.minRevision <= this.maxRevision;
+        yield* iterate(entries, forwards);
+    }
+
+    /**
+     * Iterate storage documents lazily from combined index entries.
+     *
+     * @private
+     * @returns {Generator<object|{ buffer: Buffer, time64: number, sequenceNumber: number }>}
+     */
+    *iterateDocuments() {
+        const forwards = this.minRevision <= this.maxRevision;
+        for (const entry of this.iterateEntries()) {
+            const event = this.eventStore.storage.readFrom(
+                entry.partition,
+                entry.position,
+                entry.size,
+                this.raw,
+                !forwards
+            );
+            if (event) {
+                yield event;
             }
         }
     }
 
+    /**
+     * Reset fetch state and cached selector ranges when stream boundaries changed.
+     *
+     * @returns {JoinEventStream}
+     */
+    reset() {
+        this._combinedRanges = null;
+        return super.reset();
+    }
 }
 
 export default JoinEventStream;

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -86,6 +86,25 @@ class JoinEventStream extends EventStream {
     }
 
     /**
+     * Optimize a selector tree at the given depth.
+     * Currently, optimizes away occurrences of _all.
+     *
+     * @private
+     * @param {Array<string|Array>} selectorNode
+     * @param {number} depth
+     * @returns {Array<Array<number>>|string}
+     */
+    optimize(selectorNode, depth) {
+        if (depth % 2 !== 0) {
+            return selectorNode.filter(node => node !== '_all');
+        }
+        if (selectorNode.some(node => node === '_all')) {
+            return '_all';
+        }
+        return selectorNode;
+    }
+
+    /**
      * Resolve one selector node into a sorted index-entry range.
      *
      * @private
@@ -98,6 +117,7 @@ class JoinEventStream extends EventStream {
             const index = this.eventStore.streams[selectorNode]?.index;
             return this.resolveIndexRange(index);
         }
+        selectorNode = this.optimize(selectorNode, depth);
 
         const childRanges = selectorNode.map(node => this.resolveSelectorRanges(node, depth + 1));
         return depth % 2 === 0 ? union(...childRanges) : intersect(...childRanges);

--- a/src/JoinEventStream.js
+++ b/src/JoinEventStream.js
@@ -1,6 +1,6 @@
 import EventStream from './EventStream.js';
 import { assert, iterate } from './utils/util.js';
-import { union, intersect } from './utils/indexUtil.js';
+import { union, intersect, normalizeSelector } from './utils/indexUtil.js';
 import { normalizeRevision } from './utils/apiHelpers.js';
 
 /**
@@ -34,7 +34,7 @@ class JoinEventStream extends EventStream {
         assert(Array.isArray(selector) && selector.length > 0, `Invalid selector supplied to JoinEventStream ${name}.`);
 
         this.eventStore = eventStore;
-        this.selector = this.normalizeSelector(selector);
+        this.selector = normalizeSelector(selector);
         this.streamIndex = eventStore.storage.index;
         this.minRevision = normalizeRevision(minRevision, eventStore.length);
         this.maxRevision = normalizeRevision(maxRevision, eventStore.length);
@@ -46,29 +46,6 @@ class JoinEventStream extends EventStream {
         this._iterator = null;
     }
 
-    /**
-     * Normalize selector shape to nested arrays and validate leaf types.
-     * Missing streams are allowed here to keep direct JoinEventStream construction compatible;
-     * they are treated as empty ranges.
-     *
-     * @private
-     * @param {Array<string|Array>} selector
-     * @returns {Array<string|Array>}
-     */
-    normalizeSelector(selector) {
-        const normalized = [];
-        for (const node of selector) {
-            if (typeof node === 'string') {
-                assert(node.length > 0, 'Stream names must be non-empty strings.');
-                normalized.push(node);
-                continue;
-            }
-
-            assert(Array.isArray(node) && node.length > 0, 'Each selector node must be a non-empty stream name array or string.');
-            normalized.push(this.normalizeSelector(node));
-        }
-        return normalized;
-    }
 
     /**
      * Resolve and cache the combined index-entry ranges for the full selector.
@@ -86,26 +63,8 @@ class JoinEventStream extends EventStream {
     }
 
     /**
-     * Optimize a selector tree at the given depth.
-     * Currently, optimizes away occurrences of _all.
-     *
-     * @private
-     * @param {Array<string|Array>} selectorNode
-     * @param {number} depth
-     * @returns {Array<Array<number>>|string}
-     */
-    optimize(selectorNode, depth) {
-        if (depth % 2 !== 0) {
-            return selectorNode.filter(node => node !== '_all');
-        }
-        if (selectorNode.some(node => node === '_all')) {
-            return '_all';
-        }
-        return selectorNode;
-    }
-
-    /**
      * Resolve one selector node into a sorted index-entry range.
+     * Selector is already normalized and optimized from constructor, so we just traverse and collect ranges.
      *
      * @private
      * @param {string|Array<string|Array>} selectorNode

--- a/src/utils/indexUtil.js
+++ b/src/utils/indexUtil.js
@@ -123,18 +123,14 @@ function intersect(...ranges) {
     if (ranges.length === 0) {
         return [];
     }
-
-    for (let i = 0; i < ranges.length; i++) {
-        if (ranges[i].length === 0) {
-            return [];
-        }
-    }
-
     if (ranges.length === 1) {
         return ranges[0].slice();
     }
 
     ranges.sort((a, b) => a.length - b.length);
+    if (ranges[0].length === 0) {
+        return [];
+    }
     let selected = intersectTwoIndexEntryRanges(ranges[0], ranges[1]);
     for (let i = 2; i < ranges.length && selected.length > 0; i++) {
         selected = intersectTwoIndexEntryRanges(selected, ranges[i]);

--- a/src/utils/indexUtil.js
+++ b/src/utils/indexUtil.js
@@ -1,0 +1,149 @@
+/**
+ * Merge two sorted index-entry ranges into one sorted union without duplicates.
+ * Assumes each range is sorted and contains no duplicates (by entry number).
+ *
+ * @param {Array<Array<number>>} left Sorted index-entry range.
+ * @param {Array<Array<number>>} right Sorted index-entry range.
+ * @returns {Array<Array<number>>} A new union range.
+ */
+function unionTwoIndexEntryRanges(left, right) {
+    if (left.length === 0) {
+        return right.slice();
+    }
+    if (right.length === 0) {
+        return left.slice();
+    }
+
+    const merged = new Array(left.length + right.length);
+    let leftIndex = 0;
+    let rightIndex = 0;
+    let count = 0;
+
+    while (leftIndex < left.length && rightIndex < right.length) {
+        const leftEntry = left[leftIndex];
+        const rightEntry = right[rightIndex];
+        const leftNumber = leftEntry[0];
+        const rightNumber = rightEntry[0];
+
+        if (leftNumber < rightNumber) {
+            merged[count++] = leftEntry;
+            leftIndex++;
+        } else if (rightNumber < leftNumber) {
+            merged[count++] = rightEntry;
+            rightIndex++;
+        } else {
+            merged[count++] = leftEntry;
+            leftIndex++;
+            rightIndex++;
+        }
+    }
+
+    while (leftIndex < left.length) {
+        merged[count++] = left[leftIndex++];
+    }
+    while (rightIndex < right.length) {
+        merged[count++] = right[rightIndex++];
+    }
+
+    merged.length = count;
+    return merged;
+}
+
+/**
+ * Merge multiple sorted index-entry ranges into one sorted union without duplicates.
+ * Pairwise reduction via two-way merges, optimized for realistic data with moderate overlap.
+ * Assumes each range is sorted and contains no duplicates (by entry number).
+ *
+ * @param {...Array<Array<number>>} ranges Sorted index-entry ranges.
+ * @returns {Array<Array<number>>} A new union range.
+ */
+function union(...ranges) {
+    if (ranges.length === 0) {
+        return [];
+    }
+    if (ranges.length === 1) {
+        return ranges[0].slice();
+    }
+
+    let merged = unionTwoIndexEntryRanges(ranges[0], ranges[1]);
+    for (let i = 2; i < ranges.length; i++) {
+        merged = unionTwoIndexEntryRanges(merged, ranges[i]);
+    }
+    return merged;
+}
+
+/**
+ * Intersect two sorted index-entry ranges by global number.
+ * Assumes each range is sorted and contains no duplicates (by entry number).
+ *
+ * @param {Array<Array<number>>} left Sorted index-entry range.
+ * @param {Array<Array<number>>} right Sorted index-entry range.
+ * @returns {Array<Array<number>>} A new intersection range.
+ */
+function intersectTwoIndexEntryRanges(left, right) {
+    if (left.length === 0 || right.length === 0) {
+        return [];
+    }
+
+    const selected = new Array(Math.min(left.length, right.length));
+    let leftIndex = 0;
+    let rightIndex = 0;
+    let count = 0;
+
+    while (leftIndex < left.length && rightIndex < right.length) {
+        const leftEntry = left[leftIndex];
+        const rightEntry = right[rightIndex];
+        const leftNumber = leftEntry[0];
+        const rightNumber = rightEntry[0];
+
+        if (leftNumber < rightNumber) {
+            leftIndex++;
+        } else if (rightNumber < leftNumber) {
+            rightIndex++;
+        } else {
+            selected[count++] = leftEntry;
+            leftIndex++;
+            rightIndex++;
+        }
+    }
+
+    selected.length = count;
+    return selected;
+}
+
+/**
+ * Intersect multiple sorted index-entry ranges by global number.
+ * Pairwise reduction with size-order optimization, best for moderate to high overlap.
+ * Assumes each range is sorted and contains no duplicates (by entry number).
+ *
+ * @param {...Array<Array<number>>} ranges Sorted index-entry ranges.
+ * @returns {Array<Array<number>>} A new intersection range.
+ */
+function intersect(...ranges) {
+    if (ranges.length === 0) {
+        return [];
+    }
+
+    for (let i = 0; i < ranges.length; i++) {
+        if (ranges[i].length === 0) {
+            return [];
+        }
+    }
+
+    if (ranges.length === 1) {
+        return ranges[0].slice();
+    }
+
+    ranges.sort((a, b) => a.length - b.length);
+    let selected = intersectTwoIndexEntryRanges(ranges[0], ranges[1]);
+    for (let i = 2; i < ranges.length && selected.length > 0; i++) {
+        selected = intersectTwoIndexEntryRanges(selected, ranges[i]);
+    }
+    return selected;
+}
+
+export {
+    union,
+    intersect
+};
+

--- a/src/utils/indexUtil.js
+++ b/src/utils/indexUtil.js
@@ -1,3 +1,5 @@
+import { assert } from './util.js';
+
 /**
  * Merge two sorted index-entry ranges into one sorted union without duplicates.
  * Assumes each range is sorted and contains no duplicates (by entry number).
@@ -138,8 +140,63 @@ function intersect(...ranges) {
     return selected;
 }
 
+/**
+ * Normalize selector shape for optimal evaluation.
+ *
+ * @param {string|Array<string|Array>} selector
+ * @param {number} [depth=0]
+ * @returns {string|Array<string|Array>}
+ */
+function normalizeSelector(selector, depth = 0) {
+    if (typeof selector === 'string') {
+        assert(selector.length > 0, 'Stream names must be non-empty strings.');
+        return selector;
+    }
+
+    assert(Array.isArray(selector), 'Selector must be a string or an array.');
+    const normalized = selector.map(node => normalizeSelector(node, depth + 1));
+    return optimizeSelectorNode(normalized, depth);
+}
+
+/**
+ * Optimize one normalized selector node by depth-dependent rules.
+ *
+ * @param {Array<string|Array>} selectorNode
+ * @param {number} depth
+ * @returns {string|Array<string|Array>}
+ */
+function optimizeSelectorNode(selectorNode, depth) {
+    if (selectorNode.length === 0) {
+        return [];
+    }
+    if (selectorNode.length === 1) {
+        const child = selectorNode[0];
+        // ['a'] -> 'a', [{ ... }] -> { ... }
+        if (!Array.isArray(child)) {
+            return selectorNode[0];
+        }
+        // [['a']] -> 'a', but never [['a']] -> ['a']
+        else if (child.length === 1) {
+            return child[0];
+        }
+        return selectorNode;
+    }
+    // ['a', 'a'] -> 'a'
+    if (selectorNode.every(node => node === selectorNode[0])) {
+        return selectorNode[0];
+    }
+
+    if (depth % 2 !== 0) {
+        return selectorNode.filter(node => node !== '_all');
+    }
+    if (selectorNode.some(node => node === '_all')) {
+        return '_all';
+    }
+    return selectorNode;
+}
+
 export {
     union,
-    intersect
+    intersect,
+    normalizeSelector
 };
-

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -906,6 +906,67 @@ describe('EventStore', function() {
 
     });
 
+    describe('fromStreams (combined selector fallback)', function() {
+
+        it('treats a flat array as OR across streams', function() {
+            eventstore = new EventStore({ storageDirectory });
+
+            eventstore.commit('a', [{ key: 1 }]);
+            eventstore.commit('x', [{ key: 2 }]);
+            eventstore.commit('a', [{ key: 3 }]);
+
+            const combined = eventstore.fromStreams('a-or-x', ['a', 'x']);
+            expect(combined.events.map(event => event.key)).to.eql([1, 2, 3]);
+        });
+
+        it('treats a nested single group as AND', function() {
+            eventstore = new EventStore({ storageDirectory });
+
+            eventstore.commit('a', [{ key: 1 }]);
+            eventstore.commit('x', [{ key: 2 }]);
+            eventstore.commit('a', [{ key: 3 }]);
+
+            const combined = eventstore.fromStreams('a-and-all', [['a', '_all']]);
+            expect(combined.events.map(event => event.key)).to.eql([1, 3]);
+        });
+
+        it('supports OR groups nested below one AND level', function() {
+            eventstore = new EventStore({ storageDirectory });
+
+            eventstore.commit('a', [{ key: 1 }]);
+            eventstore.commit('b', [{ key: 2 }]);
+            eventstore.commit('c', [{ key: 3 }]);
+
+            const combined = eventstore.fromStreams('a-or-b', [[['a', 'b']]]);
+            expect(combined.events.map(event => event.key)).to.eql([1, 2]);
+        });
+
+        it('applies global min/max revision window before combining index ranges', function() {
+            eventstore = new EventStore({ storageDirectory });
+
+            eventstore.commit('a', [{ key: 1 }]);
+            eventstore.commit('x', [{ key: 2 }]);
+            eventstore.commit('a', [{ key: 3 }]);
+            eventstore.commit('a', [{ key: 4 }]);
+
+            const limited = eventstore.fromStreams('a-and-all-limited', [['a', '_all']], 2, 3);
+            expect(limited.events.map(event => event.key)).to.eql([3]);
+        });
+
+        it('keeps OR ordering when iterating backwards', function() {
+            eventstore = new EventStore({ storageDirectory });
+
+            eventstore.commit('a', [{ key: 1 }]);
+            eventstore.commit('x', [{ key: 2 }]);
+            eventstore.commit('b', [{ key: 3 }]);
+            eventstore.commit('a', [{ key: 4 }]);
+
+            const combined = eventstore.fromStreams('combined-a-or-b-reverse', ['a', 'b'], -1, 1);
+            expect([...combined].map(event => event.key)).to.eql([4, 3, 1]);
+        });
+
+    });
+
     describe('getEventStreamForCategory', function() {
 
         it('throws when not specifying category without streams', function () {

--- a/test/indexUtil.spec.js
+++ b/test/indexUtil.spec.js
@@ -1,0 +1,147 @@
+import expect from 'expect.js';
+import Entry from '../src/IndexEntry.js';
+import { intersect, union } from '../src/utils/indexUtil.js';
+
+function createEntry(number, position = number * 100, size = 10, partition = Math.floor(number / 10)) {
+    return new Entry(number, position, size, partition);
+}
+
+describe('indexUtil', function() {
+
+    describe('union', function() {
+
+        it('returns empty when called without ranges', function() {
+            expect(union()).to.eql([]);
+        });
+
+        it('returns a shallow copy for a single range', function() {
+            const range = [createEntry(1), createEntry(2)];
+            const result = union(range);
+
+            expect(result).to.eql(range);
+            expect(result).not.to.be(range);
+        });
+
+        it('returns the sorted union of multiple ranges without duplicates', function() {
+            const merged = union(
+                [createEntry(1), createEntry(3), createEntry(5)],
+                [createEntry(2), createEntry(3), createEntry(6)],
+                [createEntry(3), createEntry(4), createEntry(6), createEntry(7)]
+            );
+
+            expect(merged.map(entry => entry.number)).to.eql([1, 2, 3, 4, 5, 6, 7]);
+        });
+
+        it('keeps the left entry when duplicate numbers exist in both ranges', function() {
+            const left = createEntry(4, 400, 10, 1);
+            const right = createEntry(4, 999, 99, 9);
+            const merged = union([left], [right]);
+
+            expect(merged.length).to.be(1);
+            expect(merged[0]).to.be(left);
+        });
+
+        it('supports chaining with returned arrays', function() {
+            const merged = union(
+                union([createEntry(1), createEntry(3)], [createEntry(2), createEntry(3)]),
+                [createEntry(3), createEntry(4)]
+            );
+
+            expect(merged.map(entry => entry.number)).to.eql([1, 2, 3, 4]);
+        });
+
+        it('handles empty ranges inside variadic input', function() {
+            const merged = union(
+                [],
+                [createEntry(2), createEntry(4)],
+                []
+            );
+
+            expect(merged.map(entry => entry.number)).to.eql([2, 4]);
+        });
+
+    });
+
+    describe('intersect', function() {
+
+        it('returns empty when called without ranges', function() {
+            expect(intersect()).to.eql([]);
+        });
+
+        it('returns empty when any range is empty', function() {
+            const selected = intersect(
+                [createEntry(1), createEntry(2)],
+                [],
+                [createEntry(1), createEntry(2)]
+            );
+
+            expect(selected).to.eql([]);
+        });
+
+        it('returns a shallow copy for a single range', function() {
+            const range = [createEntry(10), createEntry(20)];
+            const result = intersect(range);
+
+            expect(result).to.eql(range);
+            expect(result).not.to.be(range);
+        });
+
+        it('returns only entries that occur in every range', function() {
+            const selected = intersect(
+                [createEntry(1), createEntry(3), createEntry(5), createEntry(7)],
+                [createEntry(2), createEntry(3), createEntry(5), createEntry(8)],
+                [createEntry(3), createEntry(4), createEntry(5), createEntry(9)]
+            );
+
+            expect(selected.map(entry => entry.number)).to.eql([3, 5]);
+        });
+
+        it('works independent of input order and range sizes', function() {
+            const selected = intersect(
+                [createEntry(1), createEntry(2), createEntry(3), createEntry(4), createEntry(5), createEntry(6)],
+                [createEntry(3), createEntry(4)],
+                [createEntry(2), createEntry(3), createEntry(4), createEntry(8)]
+            );
+
+            expect(selected.map(entry => entry.number)).to.eql([3, 4]);
+        });
+
+        it('returns empty when ranges are disjoint', function() {
+            const selected = intersect(
+                [createEntry(1), createEntry(2)],
+                [createEntry(3), createEntry(4)],
+                [createEntry(5), createEntry(6)]
+            );
+
+            expect(selected).to.eql([]);
+        });
+
+        it('supports chaining merge and select operations', function() {
+            const selected = intersect(
+                union([createEntry(1), createEntry(4)], [createEntry(2), createEntry(4)]),
+                union([createEntry(2), createEntry(4)], [createEntry(3), createEntry(4)]),
+                [createEntry(4), createEntry(5)]
+            );
+
+            expect(selected.map(entry => entry.number)).to.eql([4]);
+        });
+
+    });
+
+    describe('immutability guarantees', function() {
+
+        it('does not mutate source arrays when intersect sorts ranges by length', function() {
+            const a = [createEntry(1), createEntry(2), createEntry(3)];
+            const b = [createEntry(2)];
+            const c = [createEntry(2), createEntry(3)];
+
+            intersect(a, b, c);
+
+            expect(a.map(entry => entry.number)).to.eql([1, 2, 3]);
+            expect(b.map(entry => entry.number)).to.eql([2]);
+            expect(c.map(entry => entry.number)).to.eql([2, 3]);
+        });
+
+    });
+
+});

--- a/test/indexUtil.spec.js
+++ b/test/indexUtil.spec.js
@@ -1,6 +1,10 @@
 import expect from 'expect.js';
 import Entry from '../src/IndexEntry.js';
-import { intersect, union } from '../src/utils/indexUtil.js';
+import {
+    intersect,
+    union,
+    normalizeSelector
+} from '../src/utils/indexUtil.js';
 
 function createEntry(number, position = number * 100, size = 10, partition = Math.floor(number / 10)) {
     return new Entry(number, position, size, partition);
@@ -8,13 +12,13 @@ function createEntry(number, position = number * 100, size = 10, partition = Mat
 
 describe('indexUtil', function() {
 
-    describe('union', function() {
+    describe('union', function () {
 
-        it('returns empty when called without ranges', function() {
+        it('returns empty when called without ranges', function () {
             expect(union()).to.eql([]);
         });
 
-        it('returns a shallow copy for a single range', function() {
+        it('returns a shallow copy for a single range', function () {
             const range = [createEntry(1), createEntry(2)];
             const result = union(range);
 
@@ -22,7 +26,7 @@ describe('indexUtil', function() {
             expect(result).not.to.be(range);
         });
 
-        it('returns the sorted union of multiple ranges without duplicates', function() {
+        it('returns the sorted union of multiple ranges without duplicates', function () {
             const merged = union(
                 [createEntry(1), createEntry(3), createEntry(5)],
                 [createEntry(2), createEntry(3), createEntry(6)],
@@ -32,7 +36,7 @@ describe('indexUtil', function() {
             expect(merged.map(entry => entry.number)).to.eql([1, 2, 3, 4, 5, 6, 7]);
         });
 
-        it('keeps the left entry when duplicate numbers exist in both ranges', function() {
+        it('keeps the left entry when duplicate numbers exist in both ranges', function () {
             const left = createEntry(4, 400, 10, 1);
             const right = createEntry(4, 999, 99, 9);
             const merged = union([left], [right]);
@@ -41,7 +45,7 @@ describe('indexUtil', function() {
             expect(merged[0]).to.be(left);
         });
 
-        it('supports chaining with returned arrays', function() {
+        it('supports chaining with returned arrays', function () {
             const merged = union(
                 union([createEntry(1), createEntry(3)], [createEntry(2), createEntry(3)]),
                 [createEntry(3), createEntry(4)]
@@ -50,7 +54,7 @@ describe('indexUtil', function() {
             expect(merged.map(entry => entry.number)).to.eql([1, 2, 3, 4]);
         });
 
-        it('handles empty ranges inside variadic input', function() {
+        it('handles empty ranges inside variadic input', function () {
             const merged = union(
                 [],
                 [createEntry(2), createEntry(4)],
@@ -62,13 +66,13 @@ describe('indexUtil', function() {
 
     });
 
-    describe('intersect', function() {
+    describe('intersect', function () {
 
-        it('returns empty when called without ranges', function() {
+        it('returns empty when called without ranges', function () {
             expect(intersect()).to.eql([]);
         });
 
-        it('returns empty when any range is empty', function() {
+        it('returns empty when any range is empty', function () {
             const selected = intersect(
                 [createEntry(1), createEntry(2)],
                 [],
@@ -78,7 +82,7 @@ describe('indexUtil', function() {
             expect(selected).to.eql([]);
         });
 
-        it('returns a shallow copy for a single range', function() {
+        it('returns a shallow copy for a single range', function () {
             const range = [createEntry(10), createEntry(20)];
             const result = intersect(range);
 
@@ -86,7 +90,7 @@ describe('indexUtil', function() {
             expect(result).not.to.be(range);
         });
 
-        it('returns only entries that occur in every range', function() {
+        it('returns only entries that occur in every range', function () {
             const selected = intersect(
                 [createEntry(1), createEntry(3), createEntry(5), createEntry(7)],
                 [createEntry(2), createEntry(3), createEntry(5), createEntry(8)],
@@ -96,7 +100,7 @@ describe('indexUtil', function() {
             expect(selected.map(entry => entry.number)).to.eql([3, 5]);
         });
 
-        it('works independent of input order and range sizes', function() {
+        it('works independent of input order and range sizes', function () {
             const selected = intersect(
                 [createEntry(1), createEntry(2), createEntry(3), createEntry(4), createEntry(5), createEntry(6)],
                 [createEntry(3), createEntry(4)],
@@ -106,7 +110,7 @@ describe('indexUtil', function() {
             expect(selected.map(entry => entry.number)).to.eql([3, 4]);
         });
 
-        it('returns empty when ranges are disjoint', function() {
+        it('returns empty when ranges are disjoint', function () {
             const selected = intersect(
                 [createEntry(1), createEntry(2)],
                 [createEntry(3), createEntry(4)],
@@ -116,7 +120,7 @@ describe('indexUtil', function() {
             expect(selected).to.eql([]);
         });
 
-        it('supports chaining merge and select operations', function() {
+        it('supports chaining merge and select operations', function () {
             const selected = intersect(
                 union([createEntry(1), createEntry(4)], [createEntry(2), createEntry(4)]),
                 union([createEntry(2), createEntry(4)], [createEntry(3), createEntry(4)]),
@@ -128,9 +132,9 @@ describe('indexUtil', function() {
 
     });
 
-    describe('immutability guarantees', function() {
+    describe('immutability guarantees', function () {
 
-        it('does not mutate source arrays when intersect sorts ranges by length', function() {
+        it('does not mutate source arrays when intersect sorts ranges by length', function () {
             const a = [createEntry(1), createEntry(2), createEntry(3)];
             const b = [createEntry(2)];
             const c = [createEntry(2), createEntry(3)];
@@ -144,4 +148,37 @@ describe('indexUtil', function() {
 
     });
 
+    describe('normalizeSelector', function () {
+
+        it('reduces OR branches with _all to _all', function () {
+            const normalized = normalizeSelector(['a', '_all', 'b']);
+            expect(normalized).to.eql('_all');
+        });
+
+        it('keeps single nested _all', function () {
+            const normalized = normalizeSelector([['_all']]);
+            expect(normalized).to.eql('_all');
+        });
+
+        it('keeps a single nested AND group intact', function () {
+            const normalized = normalizeSelector([['a', 'b']]);
+            expect(normalized).to.eql([['a', 'b']]);
+        });
+
+        it('flattens two single-child wrapper levels around a multi-element group', function () {
+            const normalized = normalizeSelector([[['a', 'b']]]);
+            expect(normalized).to.eql(['a', 'b']);
+        });
+
+        it('normalizes [a, [[[x]]], b] to [a, [x], b]', function () {
+            const normalized = normalizeSelector(['a', [[['x']]], 'b']);
+            expect(normalized).to.eql(['a', ['x'], 'b']);
+        });
+
+        it('normalizes [a, [[x]], b] to [a, x, b]', function () {
+            const normalized = normalizeSelector(['a', [['x']], 'b']);
+            expect(normalized).to.eql(['a', 'x', 'b']);
+        });
+
+    });
 });


### PR DESCRIPTION
This pull request introduces a new, more expressive logical stream selector API for composing event streams, replacing the previous approach with a unified selector algebra. The core change is the adoption of nested array-based selectors that alternate between `OR` and `AND` logic by depth, enabling complex queries without a separate query language. The documentation and implementation have been updated to reflect this new model, including DCB (Domain Command Bus) query compatibility and guidance on using matchers versus tag streams.

**Logical Stream Selector API and Implementation:**

- Introduced a selector algebra for `fromStreams`, where nested arrays alternate between `OR` and `AND` operators by depth, allowing for expressive composition of streams [[1]](diffhunk://#diff-611a3be1ff17e0418079eeefd0d0dc23263c4373d6f0a571a391b3a07a381aceR1-R125) [[2]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L635-R657) [[3]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L654-R667).
- Removed the separate `CombinedEventStream` in favor of a single `JoinEventStream` implementation that evaluates selector trees using index set operations (`union`/`intersect`) [[1]](diffhunk://#diff-611a3be1ff17e0418079eeefd0d0dc23263c4373d6f0a571a391b3a07a381aceR1-R125) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L13-R13) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L109-R109) [[4]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R3-R7).

**Documentation and API Updates:**

- Updated API documentation (`docs/api.md`, `docs/streams.md`, `docs/architecture.md`) to describe the new selector tree syntax, operator alternation, and examples for composing streams [[1]](diffhunk://#diff-9eddf4dc51bf6a0125ca7fb094468ad284112270385c41cebce4f8f0a29620abL243-R257) [[2]](diffhunk://#diff-e4cdcd15dee638bc58e094d6ddb948ff6909ce24623cce38c46fc1506badb3afR229-R249) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L13-R13) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L109-R109).
- Added changelog notes for version 1.4.0 to highlight the new selector algebra and DCB documentation updates.

**DCB Query Compatibility and Best Practices:**

- Documented how DCB queries (using `types` and `tags`) are compiled into selector algebra, and clarified the implementation trade-offs between using tag streams and matcher-only approaches [[1]](diffhunk://#diff-6dbb26d594e41459d6f78a8444b290e7598dd20a268a04892b33fc6ec870a992R1-R254) [[2]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637R43-R50) [[3]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637R100-R109) [[4]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L153-R178) [[5]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L170-R210).
- Provided guidance on when to use tag streams versus matcher logic, and described the migration and rollout plan for the new API [[1]](diffhunk://#diff-6dbb26d594e41459d6f78a8444b290e7598dd20a268a04892b33fc6ec870a992R1-R254) [[2]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L170-R210).

**Internal and Validation Improvements:**

- Added a utility function `assertSelectorStreamsExist` to recursively validate that all streams referenced in a selector exist, improving error handling for nested selectors [[1]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0R28-R38) [[2]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L654-R667).

**Summary of Most Important Changes:**

**Logical Selector Algebra & Implementation:**
- Added selector algebra to `fromStreams` for nested `OR`/`AND` composition, deprecating `CombinedEventStream` in favor of a unified `JoinEventStream` implementation. [[1]](diffhunk://#diff-611a3be1ff17e0418079eeefd0d0dc23263c4373d6f0a571a391b3a07a381aceR1-R125) [[2]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L635-R657) [[3]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L654-R667)
- Updated internal validation to ensure all streams in complex selectors exist using `assertSelectorStreamsExist`. [[1]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0R28-R38) [[2]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L654-R667)

**Documentation & API:**
- Revised API and architecture docs to explain the new selector model, including usage examples and operator alternation by depth. [[1]](diffhunk://#diff-9eddf4dc51bf6a0125ca7fb094468ad284112270385c41cebce4f8f0a29620abL243-R257) [[2]](diffhunk://#diff-e4cdcd15dee638bc58e094d6ddb948ff6909ce24623cce38c46fc1506badb3afR229-R249) [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L13-R13) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L109-R109)
- Updated changelog for v1.4.0 to reflect these major changes.

**DCB Query Support & Best Practices:**
- Documented DCB query translation to selector algebra, clarified matcher-only vs. tag stream approaches, and provided migration guidance. [[1]](diffhunk://#diff-6dbb26d594e41459d6f78a8444b290e7598dd20a268a04892b33fc6ec870a992R1-R254) [[2]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637R43-R50) [[3]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637R100-R109) [[4]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L153-R178) [[5]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L170-R210)

These changes provide a more powerful and flexible foundation for logical stream composition and DCB query compatibility.