### PR TITLE
Add support for dcb.events style DCB query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ node_modules
 /*/node_modules
 /.claude/settings.local.json
 /.mcp.json
+/*/data
+/.agentbridge/

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -60,6 +60,39 @@ const eventstore = new EventStore('my-event-store', {
 });
 ```
 
+## Dynamic Stream Indexing
+
+On every `commit()`, EventStore can automatically maintain dedicated streams for any payload property. The high-level options `typeAccessor` and `tagsAccessor` are convenient shorthands; `streamSources` is the generic mechanism they build on.
+
+Each entry in `streamSources` specifies a dot-notation `path` into the event payload and a `nameBuilder(value) => streamName` function. Scalar property values are passed to `nameBuilder` directly; array values are iterated so each element produces its own stream. Non-string and empty values are skipped silently.
+
+```javascript
+const store = new EventStore('my-store', {
+    storageDirectory: './data',
+    streamSources: [
+        // one stream per tenant — 'acme' → stream 'tenant/acme'
+        { path: 'tenantId', nameBuilder: (v) => `tenant/${v}` },
+        // one stream per tag value (equivalent to tagsAccessor: 'tags')
+        { path: 'tags',     nameBuilder: (v) => `tags/${v}` }
+    ]
+});
+```
+
+`typeAccessor` and `tagsAccessor` are shorthand for:
+
+```javascript
+streamSources: [
+    { path: 'type', nameBuilder: (v) => v },           // typeAccessor: 'type'
+    { path: 'tags', nameBuilder: (v) => `tags/${v}` }  // tagsAccessor: 'tags'
+]
+```
+
+with the additional benefit that `typeAccessor` and `tagsAccessor` also wire into `DcbQuery` resolution for the `types` and `tags` fields.
+
+Each source's `payload.<path>` is automatically added to `matcherProperties` so the IndexMatcher routes index writes in O(1) rather than scanning all registered matchers.
+
+---
+
 ## Storage Configuration
 
 Pass these options inside `config.storageConfig`:

--- a/docs/api.md
+++ b/docs/api.md
@@ -544,11 +544,11 @@ Matcher behavior differs by mode:
   - Function matcher: `(buffer) => boolean` where `buffer` is one compact JSON document
   - Object matcher: byte-level raw matcher over compact JSON bytes (lazy-built at first stream consumption)
 
-Object matchers support nested equality, array values with OR semantics, and scalar comparison operators (`$gt`, `$gte`, `$lt`, `$lte`, `$eq`, `$ne`). Multiple operators on the same field are combined with AND semantics.
+Object matchers support nested equality, array values with OR semantics, scalar comparison operators (`$gt`, `$gte`, `$lt`, `$lte`, `$eq`, `$ne`), and array-containment via `$has`. Multiple operators on the same field are combined with AND semantics; `$has` must be used on its own.
 
 Prefer plain equality over `$eq` when possible (`{ type: 'Foo' }` instead of `{ type: { $eq: 'Foo' } }`).
 
-Operator matching is intended for scalar values. For arrays, objects, or custom raw encodings, use plain equality or a function matcher.
+Operator matching (comparison operators) is intended for scalar values. For array containment use `$has` (e.g. `{ tags: { $has: 'featured' } }`); for other array/object shapes or custom raw encodings, use a function matcher.
 
 The raw object matcher requires the default compact JSON serializer format. If you use a custom serializer (including pretty-printed or transformed JSON), object matchers in raw mode are not guaranteed to work; use a function matcher in that case.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 - Added `DcbQuery` shorthand syntax for `query()`: pass `{ items: [{ types, tags }] }` directly instead of constructing the nested selector algebra by hand. Requires `typeAccessor` and/or `tagsAccessor` to be configured for the respective fields.
 - Added `tagsAccessor` option: dot-notation path to an array of tag strings in the event payload. On every `commit()`, one `tags/{tag}` stream is created per distinct value with O(1) IndexMatcher routing.
 - Added `streamSources` option: generic stream-index definitions as `[{ path, nameBuilder }]` entries. `typeAccessor` and `tagsAccessor` are now shorthands that register a source internally; custom sources can produce any stream name from any payload property, including array-valued fields.
+- Added `$has` object-matcher operator for array-containment checks (`{ tags: { $has: 'featured' } }`). Compiles to a fast byte-level scan in raw mode and to `Array.isArray(v) && v.includes(x)` in object mode. Tag-stream matchers built by `tagsAccessor`/`streamSources` for array-valued fields now use `$has` internally so `IndexMatcher` can route them via the O(1) discriminant table.
 
 ## 1.3.5
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,13 @@
 
 - Extended `JoinEventStream` with nested selector-algebra composition (`OR` at depth 0, `AND` at depth 1, then alternating), available through `fromStreams`.
 - Updated DCB documentation to describe `types`/`tags` semantics with optional tag-stream indexing and matcher-only execution trade-offs.
+- Added `DcbQuery` shorthand syntax for `query()`: pass `{ items: [{ types, tags }] }` directly instead of constructing the nested selector algebra by hand. Requires `typeAccessor` and/or `tagsAccessor` to be configured for the respective fields.
+- Added `tagsAccessor` option: dot-notation path to an array of tag strings in the event payload. On every `commit()`, one `tags/{tag}` stream is created per distinct value with O(1) IndexMatcher routing.
+- Added `streamSources` option: generic stream-index definitions as `[{ path, nameBuilder }]` entries. `typeAccessor` and `tagsAccessor` are now shorthands that register a source internally; custom sources can produce any stream name from any payload property, including array-valued fields.
+
+## 1.3.5
+
+- Fix edge case in JoinStream when reading interleaved streams that lead to read buffer backtracking
 
 ## 1.3.4
 

--- a/docs/dcb.md
+++ b/docs/dcb.md
@@ -20,55 +20,107 @@ DCB resolves this by letting each command handler declare exactly which events i
 
 ---
 
-## The DCB Workflow
+## The DCB Query Model
 
-### Step 1 — Query for the transaction context
+The formal DCB specification (see [dcb.events](https://dcb.events)) expresses every read intent as a list of **query items**. Each item pairs an array of event types with an array of **domain-identifier tags**:
+
+```javascript
+const queryItems = [
+    { types: ['CourseCreated', 'CourseCapacityChanged', 'StudentSubscribedToCourse'],
+      tags:  ['course/jdsj4'] },
+    { types: ['StudentCreated', 'StudentSubscribedToCourse'],
+      tags:  ['student/gfh3j'] }
+];
+```
+
+An event matches when **any** item matches it: the event's type must be in that item's `types` **and** the event must carry **all** of that item's tags.
+
+- **Items** combine with **OR** — any matching item is sufficient.
+- **`tags` within an item** combine with **AND** — all tags must be present.
+- **`types` within an item** combine with **OR** — any listed type is sufficient.
+
+Both `types` and `tags` are optional per item. An item without `types` matches all event types; an item without `tags` requires no tag match. An item with neither selects all events.
+
+---
+
+## Using DCB in event-storage
+
+DCB workflows follow four steps that map directly to the query model above.
+
+### Step 1 — Configure stream indexes
+
+`query()` operates on named streams. Configure `typeAccessor` and `tagsAccessor` so the store creates and maintains those streams automatically on every `commit()`:
+
+```javascript
+const store = new EventStore('my-store', {
+    storageDirectory: './data',
+    typeAccessor: 'type',   // dot-notation path to the event type field in the payload
+    tagsAccessor: 'tags'    // dot-notation path to an array of tag strings in the payload
+});
+```
+
+`typeAccessor` creates one dedicated stream per distinct event-type value — `CourseCreated`, `StudentSubscribedToCourse`, etc. `tagsAccessor` creates one stream per tag value under `tags/{tag}` — `'course/jdsj4'` becomes stream `tags/course/jdsj4`. Tag values are recommended to use `/` as a hierarchy separator.
+
+Both property paths are automatically registered in the IndexMatcher discriminant table so stream routing on every write is O(1).
+
+> **New stores only:** stream indexes are created with `reindex=false` and only cover events committed after the index first appears. Configure both options from the beginning if you intend to use `query()`.
+
+### Step 2 — Query with DcbQuery
+
+Pass a `DcbQuery` object directly to `query()`. Its `items` array maps one-to-one to the query model:
+
+```javascript
+const { stream, condition } = store.query({
+    items: [
+        { types: ['CourseCreated', 'CourseCapacityChanged'], tags: ['course/jdsj4'] },
+        { types: ['StudentCreated'],                          tags: ['student/gfh3j'] }
+    ]
+});
+```
+
+`query()` detects the `{ items }` shape, compiles each item to the equivalent selector algebra internally, and returns:
+
+- **`stream`** — an `EventStream` of all matching events.
+- **`condition`** — the query definition and current global event-log position; pass it to `commit()` to enforce the concurrency check.
+
+An optional second argument further narrows the boundary to exactly the events that would affect the decision:
 
 ```javascript
 const { stream, condition } = store.query(
-    ['OrderPlaced', 'OrderShipped'],                           // event types to watch
-    (event, metadata) => event.orderId === 'order-42'          // optional filter
+    { items: [{ types: ['OrderPlaced', 'OrderShipped'] }] },
+    (event, metadata) => event.orderId === 'order-42'   // optional matcher
 );
 ```
 
-- `stream` — an `EventStream` filtered to events of the given types that also satisfy the optional matcher.
-- `condition` — captures the current global event-log position; pass it to `commit()` to enforce the concurrency check.
+The matcher can be a predicate function or the object-matcher syntax (see [Event Streams → Object Matcher Syntax](streams.md#object-matcher-syntax)). Unrelated events of the same type (e.g. a different order) never cause spurious conflicts.
 
-The optional `matcher` narrows the boundary to exactly the events that would affect the decision — unrelated events of the same type (e.g. a different order) never cause spurious conflicts.
+> **Note:** streams listed in the query that do not exist yet are still checked correctly at commit time — a stream created by another writer between `query()` and `commit()` is included in the conflict check.
 
-That `matcher` can be either a predicate function or the same object-matcher syntax used by streams: nested equality, array values with OR semantics, and scalar operators like `$gte` / `$lt`. See [Event Streams -> Object Matcher Syntax](streams.md#object-matcher-syntax).
+`query()` treats missing referenced streams as empty sets — a missing stream in an `OR` group has no effect; a missing stream in an `AND` group makes that branch yield nothing.
 
-The first argument to `query()` accepts the full selector algebra — the same nested array structure as `fromStreams()`. A flat `['TypeA', 'TypeB']` is equivalent to a top-level OR join over those streams. Nested arrays express AND (intersection) at odd depths and OR at even depths. See [The DCB Specification: Types and Tags](#the-dcb-specification-types-and-tags) for complete examples.
+### Step 3 — Build the decision model
 
-`query()` also supports raw mode (`query(selector, matcher, minRevision, true)`), but raw streaming itself is a general stream-reading feature, not DCB-specific. See [Event Streams -> Reading Streams](streams.md#reading-streams) for the full raw-mode semantics and matcher behavior.
-
-### Implementation detail: selector algebra when tags are indexed as streams
-
-The important DCB concept is `types` + `tags` selection semantics. How this is executed is an implementation detail.
-
-If tags are materialized as dedicated streams, DCB items naturally compile to nested selector algebra — which `query()` accepts directly, returning both the filtered stream and the concurrency condition in a single call.
-
-If tags are not materialized as streams, the same semantics can be expressed entirely through matcher logic.
-
-### Step 2 — Build the decision model
+Iterate the stream to reconstruct the application state relevant to the command:
 
 ```javascript
-const model = new OrderModel();
+const model = new CourseModel();
 stream.forEach((event, metadata) => {
     model.apply(event);
 });
 ```
 
-### Step 3 — Commit with the condition
+### Step 4 — Commit with the condition
+
+Commit the resulting events together with the condition captured in Step 2:
 
 ```javascript
 try {
-    store.commit('order-42', [{ type: 'OrderShipped', orderId: 'order-42', ... }], condition, () => {
-        console.log('Committed successfully');
-    });
+    store.commit('enrollment-...', [
+        { type: 'StudentSubscribedToCourse', courseId: 'jdsj4', studentId: 'gfh3j', tags: ['course/jdsj4', 'student/gfh3j'] }
+    ], condition);
 } catch (e) {
     if (e instanceof EventStore.OptimisticConcurrencyError) {
-        // A conflicting event appeared — replay and retry
+        // A conflicting event appeared between query and commit — replay and retry
     }
 }
 ```
@@ -83,36 +135,6 @@ try {
 | New events appeared, but none match the `matcher` | ✅ No conflict |
 | New events appeared and at least one matches the `matcher` | ❌ `OptimisticConcurrencyError` |
 | New events appeared and no `matcher` was provided | ❌ `OptimisticConcurrencyError` |
-
----
-
-## Enabling DCB-style Queries with `typeAccessor`
-
-`query()` requires a named stream per event type. Configure `typeAccessor` to have those streams created and maintained automatically on every `commit()`:
-
-```javascript
-const store = new EventStore('my-store', {
-    storageDirectory: './data',
-    typeAccessor: 'type'   // dot-notation path to the type field in the event payload
-});
-```
-
-`typeAccessor` accepts a dot-notation path string (e.g. `'type'`, `'meta.kind'`) pointing to the event type field, which also enables faster index routing. For non-standard event layouts a function `(event) => string` can be used instead.
-
-Type stream names currently map directly to event types (for example `CourseCreated`).
-
-`query()` treats missing referenced streams as empty sets. This applies both to type-stream lists and nested selector algebra.
-
-In selector terms:
-
-- missing stream in an `OR` group: no effect,
-- missing stream in an `AND` group: that branch becomes empty.
-
-> **New stores only**: type indexes are built with `reindex=false` — they only cover events committed *after* the index was first created. Always configure `typeAccessor` from the beginning if you intend to use `query()`.
-
-> **CommitCondition timing**: the condition captures the global store length at the moment `query()` is called. At commit time, the conflict check includes all streams referenced by the selector that exist *at that point* — including streams created between the `query()` and `commit()` calls. This means a type stream or tag stream created by another writer during that window is automatically included in the conflict check, with no race gap.
-
-Tag streams are optional. DCB queries can be implemented without any tag streams by using matcher logic only.
 
 ---
 
@@ -154,54 +176,13 @@ store.on('ready', () => {
 
 ---
 
-## The DCB Specification: Types and Tags
+## Without Tag Streams — Matcher-Only Queries
 
-The formal DCB specification expresses a query as a list of **query items**, each pairing an array of event types with an array of **domain-identifier tags**:
-
-```
-queryItems = [
-  { types: ['CourseCreated', 'CourseCapacityChanged', 'StudentSubscribedToCourse'],
-    tags:  ['course:jdsj4'] },
-  { types: ['StudentCreated', 'StudentSubscribedToCourse'],
-    tags:  ['student:gfh3j'] }
-]
-```
-
-An event matches when **any** item matches it: the event's type must be in that item's `types` **and** the event must carry **all** of that item's tags.
-
-Equivalent selector intent (when tags are represented as streams):
-
-- query level (`items`): `OR`
-- per-item `tags`: `AND`
-- per-item `types`: `OR`
-
-When tags are materialized as dedicated streams, pass the nested selector directly to `query()` — it returns both the filtered stream and the concurrency condition in one call, using the same alternating OR/AND depth semantics described in [Joining Streams](streams.md#joining-streams):
+Tag streams are optional. When tag cardinality is low or write throughput is the primary concern, encode the per-item tag logic in the `matcher` instead. Pass the union of all relevant types and evaluate tag membership at read time:
 
 ```javascript
-const courseId  = 'course:jdsj4';
-const studentId = 'student:gfh3j';
-
-const { stream, condition } = store.query([
-    [courseId, ['CourseCreated', 'CourseCapacityChanged', 'StudentSubscribedToCourse']],
-    [studentId, ['StudentCreated', 'StudentSubscribedToCourse']]
-]);
-```
-
-- depth 0 (top-level array): OR across query items
-- depth 1 (second-level arrays): AND — tag stream intersected with the type-group stream
-- depth 2 (third-level arrays): OR across event types
-
-Selection happens at the index level: only events at the intersection of the tag stream and the relevant type streams are yielded, without deserializing unrelated documents. Missing streams are treated as empty — an `OR` branch with no matching stream is skipped; an `AND` branch containing a missing stream yields nothing.
-
-```javascript
-store.commit('enrollment-...', [{ type: 'StudentSubscribedToCourse', ... }], condition);
-```
-
-Without tag streams, the same intent can be expressed using the `matcher` function. Pass the union of all types, and encode per-item tag logic in the matcher:
-
-```javascript
-const courseId  = 'course:jdsj4';
-const studentId = 'student:gfh3j';
+const courseId  = 'course/jdsj4';
+const studentId = 'student/gfh3j';
 
 const { stream, condition } = store.query(
     ['CourseCreated', 'CourseCapacityChanged', 'StudentCreated', 'StudentSubscribedToCourse'],
@@ -214,6 +195,10 @@ const { stream, condition } = store.query(
 );
 ```
 
+This requires no `tagsAccessor` configuration and no tag-stream writes. The trade-off is that more events must be deserialized at read time to evaluate the matcher.
+
+---
+
 ## Choosing Between Matcher-Only and Tag Streams
 
 Both approaches are valid and can coexist.
@@ -223,8 +208,8 @@ Both approaches are valid and can coexist.
 
 Rule of thumb:
 
-- higher write load / lower read selectivity pressure -> matcher-only is often better,
-- lower write load / high tag diversity with many matcher misses -> tag streams are often better.
+- higher write load / lower read selectivity pressure → matcher-only is often better,
+- lower write load / high tag diversity with many matcher misses → tag streams are often better.
 
 ### Benchmark findings and practical recommendation
 
@@ -248,7 +233,7 @@ Recent measurements with that setup produced the following excerpt:
 Mode definitions and how to apply them in practice:
 
 - **Matcher-only**: query by event types and evaluate tags only via matcher logic at read time. Practical setup: keep type streams, avoid tag streams, call `query(types, matcher)`.
-- **Tag-streams**: materialize tags as dedicated streams and build DCB context from stream selectors. Practical setup: create tag streams (manually or in pre-commit) and query through `query()` with nested selector algebra.
+- **Tag-streams**: materialize tags as dedicated streams and build DCB context from stream selectors. Practical setup: configure `tagsAccessor` and use `DcbQuery` or nested selector algebra via `query()`.
 - **Semester-bounded stream**: write all decision-relevant events for a semester into `semesters/{id}` so the read context stays naturally bounded. Practical setup: choose business-bounded write streams first, then query only within that boundary.
 
 This demonstrates three important points:
@@ -263,3 +248,26 @@ For the semester case specifically, realistic systems typically need one more fi
 
 - keep one semester stream and intersect with enrollment-related event types during context read,
 - split into `semester/{id}/students`, `semester/{id}/courses`, and `semester/{id}/enrolments`, then build the DCB context from the join of those three streams.
+
+---
+
+## Selector Algebra (Advanced)
+
+`DcbQuery` compiles each item to the nested selector algebra that `query()` and `fromStreams()` understand natively. The algebra uses alternating OR/AND depth semantics (see [Joining Streams](streams.md#joining-streams)):
+
+- depth 0 (top-level array): OR across query items
+- depth 1 (per-item array): AND — tag stream intersected with the type-group stream
+- depth 2 (inner array): OR across event types
+
+The compiled form of the earlier DcbQuery example is equivalent to:
+
+```javascript
+const { stream, condition } = store.query([
+    ['tags/course/jdsj4', ['CourseCreated', 'CourseCapacityChanged']],
+    ['tags/student/gfh3j', ['StudentCreated']]
+]);
+```
+
+Selection happens at the index level: only events at the intersection of the tag stream and the relevant type streams are yielded, without deserializing unrelated documents.
+
+You can pass the nested array form directly to `query()` when the query shape cannot be expressed as a flat list of `{ types, tags }` items, or when you want full control over which streams are joined. A flat `['TypeA', 'TypeB']` is a top-level OR join over those streams. `query()` also supports raw mode — see [Event Streams → Reading Streams](streams.md#reading-streams).

--- a/docs/dcb.md
+++ b/docs/dcb.md
@@ -178,24 +178,40 @@ store.on('ready', () => {
 
 ## Without Tag Streams — Matcher-Only Queries
 
-Tag streams are optional. When tag cardinality is low or write throughput is the primary concern, encode the per-item tag logic in the `matcher` instead. Pass the union of all relevant types and evaluate tag membership at read time:
+Tag streams are optional. When tag cardinality is low or write throughput is the primary concern, encode the per-item tag logic in the `matcher` instead. Pass the union of all relevant types and evaluate tag membership at read time.
+
+**Prefer the object-matcher `$has` operator** over a function matcher for tag containment — `$has` compiles to a fast byte-level check in raw mode and is significantly cheaper than deserialising and invoking a JS function per event.
 
 ```javascript
 const courseId  = 'course/jdsj4';
 const studentId = 'student/gfh3j';
 
+// $has performs an array-containment check on payload.tags without a function matcher.
+const { stream, condition } = store.query(
+    ['CourseCreated', 'CourseCapacityChanged', 'StudentCreated', 'StudentSubscribedToCourse'],
+    {
+        payload: { tags: { $has: courseId } }
+        // For an OR across multiple tags, either widen the type list and post-filter,
+        // or issue two queries and merge — a single matcher only expresses one $has value.
+    }
+);
+```
+
+If the per-item logic really needs cross-field OR/AND semantics that the object matcher cannot express, fall back to a function matcher:
+
+```javascript
 const { stream, condition } = store.query(
     ['CourseCreated', 'CourseCapacityChanged', 'StudentCreated', 'StudentSubscribedToCourse'],
     (event, meta) =>
         (['CourseCreated', 'CourseCapacityChanged', 'StudentSubscribedToCourse'].includes(event.type)
-            && meta.tags?.includes(courseId))
+            && event.tags?.includes(courseId))
         ||
         (['StudentCreated', 'StudentSubscribedToCourse'].includes(event.type)
-            && meta.tags?.includes(studentId))
+            && event.tags?.includes(studentId))
 );
 ```
 
-This requires no `tagsAccessor` configuration and no tag-stream writes. The trade-off is that more events must be deserialized at read time to evaluate the matcher.
+Both variants require no `tagsAccessor` configuration and no tag-stream writes. The trade-off is that more events must be deserialised at read time to evaluate the matcher; `$has` keeps that overhead close to a raw byte scan, while function matchers force full JSON parsing per event.
 
 ---
 

--- a/docs/dcb.md
+++ b/docs/dcb.md
@@ -211,7 +211,7 @@ const { stream, condition } = store.query(
 );
 ```
 
-Both variants require no `tagsAccessor` configuration and no tag-stream writes. The trade-off is that more events must be deserialised at read time to evaluate the matcher; `$has` keeps that overhead close to a raw byte scan, while function matchers force full JSON parsing per event.
+Both variants require no `tagsAccessor` configuration and no tag-stream writes. The trade-off is that more events must be deserialized at read time to evaluate the matcher; `$has` keeps that overhead close to a raw byte scan, while function matchers force full JSON parsing per event.
 
 ---
 

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -148,8 +148,14 @@ Supported forms:
   ```
 
 Supported operators are `$gt`, `$gte`, `$lt`, `$lte`, `$eq`, `$ne`, and `$has`.
-Multiple operators on the same field are combined with AND semantics, except `$has`
-which must be used on its own for a given field.
+Multiple operators on the same field are combined with AND semantics, but only when
+they operate on the same value shape. `$gt`/`$gte`/`$lt`/`$lte`/`$eq`/`$ne` are scalar
+operators and can be freely combined (e.g. `{ $gte: 100, $lt: 1000 }`). `$has` is a
+non-scalar (array-containment) operator and cannot be combined with scalar operators —
+`{ $has: 'tag', $gt: 10 }` is nonsensical because a value cannot simultaneously be an
+array (for `$has`) and a scalar comparable to `10`. Future non-scalar operators (e.g. a
+hypothetical `$length`) may be combinable with `$has` but likewise not with scalar
+operators.
 
 `$eq` is equivalent to plain equality, so prefer the simpler form when possible:
 

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -124,6 +124,17 @@ Supported forms:
   { payload: { type: ['OrderPlaced', 'OrderCancelled'] } }
   ```
 
+- **Array document values with scalar matcher (containment check)**
+
+  When the document field is an array and the matcher value is a scalar, the match
+  succeeds if the array contains that value.
+
+  ```javascript
+  // matches events whose payload.tags array includes 'featured'
+  { payload: { tags: 'featured' } }
+  // equivalent to: event.payload.tags.includes('featured')
+  ```
+
 - **Scalar comparison operators**
 
   ```javascript

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -124,16 +124,22 @@ Supported forms:
   { payload: { type: ['OrderPlaced', 'OrderCancelled'] } }
   ```
 
-- **Array document values with scalar matcher (containment check)**
+- **Array containment with `$has`**
 
-  When the document field is an array and the matcher value is a scalar, the match
-  succeeds if the array contains that value.
+  When the document field is an array and you want to match documents that contain a
+  specific scalar element, use the `$has` operator. A plain scalar matcher against an
+  array-valued field is always exact-equality (i.e. never matches an array).
 
   ```javascript
   // matches events whose payload.tags array includes 'featured'
-  { payload: { tags: 'featured' } }
-  // equivalent to: event.payload.tags.includes('featured')
+  { payload: { tags: { $has: 'featured' } } }
+  // equivalent to: Array.isArray(event.payload.tags) && event.payload.tags.includes('featured')
   ```
+
+  `$has` compiles to a fast byte-level check in raw mode: the compiled matcher locates
+  the `"tags":[` opener and scans the array's element level for the serialized scalar
+  without parsing nested objects. Use `$has` instead of a function matcher wherever
+  possible for tag-membership predicates.
 
 - **Scalar comparison operators**
 
@@ -141,8 +147,9 @@ Supported forms:
   { payload: { amount: { $gte: 100, $lt: 1000 } } }
   ```
 
-Supported operators are `$gt`, `$gte`, `$lt`, `$lte`, `$eq`, and `$ne`.
-Multiple operators on the same field are combined with AND semantics.
+Supported operators are `$gt`, `$gte`, `$lt`, `$lte`, `$eq`, `$ne`, and `$has`.
+Multiple operators on the same field are combined with AND semantics, except `$has`
+which must be used on its own for a given field.
 
 `$eq` is equivalent to plain equality, so prefer the simpler form when possible:
 

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -8,7 +8,7 @@ import Index from './Index.js';
 import Consumer from './Consumer.js';
 import { assert, compileAccessor } from './utils/util.js';
 import { ensureDirectory, resolvePath, scanForFiles } from './utils/fsUtil.js';
-import { buildTypeMatcherFn } from './utils/metadataUtil.js';
+import { buildTypeMatcherFn, buildTagMatcherFn } from './utils/metadataUtil.js';
 import { fixCommitArgumentTypes, parseStreamFromIndexName, normalizePredicateRaw } from './utils/apiHelpers.js';
 import { normalizeSelector } from "./utils/indexUtil.js";
 import { isDcbQuery, compileDcbQuery } from "./utils/dcbUtil.js";
@@ -116,20 +116,20 @@ class EventStore extends events.EventEmitter {
 
         if (config.typeAccessor) {
             assert(typeof config.typeAccessor === 'string', 'typeAccessor must be a dot-notation string path (e.g. \'type\').');
-            this.typeSource = { path: config.typeAccessor, accessor: compileAccessor(config.typeAccessor), nameBuilder: (v) => v, matcherFn: buildTypeMatcherFn(config.typeAccessor) };
+            this.typeSource = { path: config.typeAccessor, accessor: compileAccessor(config.typeAccessor), nameBuilder: (v) => v, matcherFn: buildTypeMatcherFn(config.typeAccessor), tagMatcherFn: buildTagMatcherFn(config.typeAccessor) };
             this.streamSources.push(this.typeSource);
         }
 
         if (config.tagsAccessor) {
             assert(typeof config.tagsAccessor === 'string', 'tagsAccessor must be a dot-notation string path (e.g. \'tags\').');
-            this.tagsSource = { path: config.tagsAccessor, accessor: compileAccessor(config.tagsAccessor), nameBuilder: (v) => `tags/${v}`, matcherFn: buildTypeMatcherFn(config.tagsAccessor) };
+            this.tagsSource = { path: config.tagsAccessor, accessor: compileAccessor(config.tagsAccessor), nameBuilder: (v) => `tags/${v}`, matcherFn: buildTypeMatcherFn(config.tagsAccessor), tagMatcherFn: buildTagMatcherFn(config.tagsAccessor) };
             this.streamSources.push(this.tagsSource);
         }
 
         for (const { path, nameBuilder } of config.streamSources ?? []) {
             assert(typeof path === 'string' && path, 'Each streamSources entry must have a non-empty string path.');
             assert(typeof nameBuilder === 'function', 'Each streamSources entry must have a nameBuilder function.');
-            this.streamSources.push({ path, nameBuilder, accessor: compileAccessor(path), matcherFn: buildTypeMatcherFn(path) });
+            this.streamSources.push({ path, nameBuilder, accessor: compileAccessor(path), matcherFn: buildTypeMatcherFn(path), tagMatcherFn: buildTagMatcherFn(path) });
         }
 
         this.storageDirectory = resolvePath(config.storageDirectory || /* istanbul ignore next */ './data');
@@ -464,16 +464,18 @@ class EventStore extends events.EventEmitter {
      */
     ensureStreams(events) {
         if (this.streamSources.length === 0) return;
-        for (const { accessor, nameBuilder, matcherFn, path } of this.streamSources) {
+        for (const { accessor, nameBuilder, matcherFn, tagMatcherFn, path } of this.streamSources) {
             for (const event of events) {
                 const raw = accessor(event);
-                const values = Array.isArray(raw) ? raw : (raw != null && raw !== '' ? [raw] : []);
+                const isArrayValue = Array.isArray(raw);
+                const values = isArrayValue ? raw : (raw != null && raw !== '' ? [raw] : []);
                 for (const value of values) {
                     if (typeof value !== 'string' || !value) continue;
                     const streamName = nameBuilder(value);
                     assert(STREAM_NAME_PATTERN.test(streamName), `Invalid stream name "${streamName}" derived from path "${path}".`);
                     if (!(streamName in this.streams)) {
-                        this.createEventStream(streamName, matcherFn(value), false);
+                        const buildMatcher = isArrayValue ? tagMatcherFn : matcherFn;
+                        this.createEventStream(streamName, buildMatcher(value), false);
                     }
                 }
             }

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -6,7 +6,7 @@ import events from 'events';
 import Storage, { ReadOnly as ReadOnlyStorage, LOCK_THROW, LOCK_RECLAIM } from './Storage.js';
 import Index from './Index.js';
 import Consumer from './Consumer.js';
-import { assert, compileAccessor } from './utils/util.js';
+import { assert } from './utils/util.js';
 import { ensureDirectory, resolvePath, scanForFiles } from './utils/fsUtil.js';
 import { fixCommitArgumentTypes, parseStreamFromIndexName, normalizePredicateRaw } from './utils/apiHelpers.js';
 import { normalizeSelector, buildStreamSource } from "./utils/indexUtil.js";

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -11,6 +11,7 @@ import { ensureDirectory, resolvePath, scanForFiles } from './utils/fsUtil.js';
 import { buildTypeMatcherFn } from './utils/metadataUtil.js';
 import { fixCommitArgumentTypes, parseStreamFromIndexName, normalizePredicateRaw } from './utils/apiHelpers.js';
 import { normalizeSelector } from "./utils/indexUtil.js";
+import { isDcbQuery, compileDcbQuery } from "./utils/dcbUtil.js";
 
 const ExpectedVersion = {
     Any: -1,
@@ -28,6 +29,17 @@ class OptimisticConcurrencyError extends Error {}
 
 /**
  * @typedef {string | SelectorNode[]} SelectorNode
+ */
+
+/**
+ * @typedef {object} QueryItem
+ * @property {string[]} [types] Event type names to match (OR within the group).
+ * @property {string[]} [tags] Tag values to match (each tag is ANDed with the others and with types).
+ */
+
+/**
+ * @typedef {object} DcbQuery
+ * @property {QueryItem[]} items Non-empty array of query items combined with OR semantics at the top level.
  */
 
 /**
@@ -75,6 +87,11 @@ class EventStore extends events.EventEmitter {
      * @param {string|function(object): string} [config.typeAccessor] Dot-notation path (e.g. `'type'`) or
      *   function `(event) => string` identifying the event type. Enables type-based queries via
      *   {@link EventStore#query} and ensures proper index routing for those queries.
+     * @param {string|function(object): string[]} [config.tagsAccessor] Dot-notation path (e.g. `'tags'`) or
+     *   function `(event) => string[]` extracting tag values from an event payload on write. On each
+     *   {@link EventStore#commit}, one stream per tag is created under `tags/{tag}`. Enables tag-scoped
+     *   {@link DcbQuery} items via {@link EventStore#query}. Tag values are recommended to use `/` as a
+     *   hierarchy separator (e.g. `'course/jdsj4'` → stream `tags/course/jdsj4`).
      * @param {object|function(string): object} [config.streamMetadata] A metadata object or a function `(streamName) => object`
      *   that is called whenever a new stream partition is created. The returned object is stored once in the partition
      *   file header and surfaced to `preCommit` / `preRead` hooks. Takes precedence only when
@@ -94,6 +111,13 @@ class EventStore extends events.EventEmitter {
         } else {
             this.typeAccessor = typeof config.typeAccessor === 'function' ? config.typeAccessor : null;
             this.typeMatcherFn = null;
+        }
+
+        if (typeof config.tagsAccessor === 'string' && config.tagsAccessor) {
+            const accessorPath = config.tagsAccessor;
+            this.tagsAccessor = (event) => getPropertyAtPath(event, accessorPath) ?? [];
+        } else {
+            this.tagsAccessor = typeof config.tagsAccessor === 'function' ? config.tagsAccessor : null;
         }
 
         this.storageDirectory = resolvePath(config.storageDirectory || /* istanbul ignore next */ './data');
@@ -441,6 +465,34 @@ class EventStore extends events.EventEmitter {
     }
 
     /**
+     * Ensure a dedicated tag stream exists for each tag on each event, creating it if needed.
+     * Must be called before the entity stream is created (same ordering requirement as ensureTypeStreams).
+     *
+     * @private
+     * @param {Array<object>} events The events to process.
+     */
+    ensureTagStreams(events) {
+        if (!this.tagsAccessor) return;
+        const tagsAccessor = this.tagsAccessor;
+        for (const event of events) {
+            const tags = tagsAccessor(event);
+            if (!Array.isArray(tags)) continue;
+            for (const tag of tags) {
+                if (typeof tag !== 'string' || !tag) continue;
+                const streamName = 'tags/' + tag;
+                if (!(streamName in this.streams)) {
+                    const tagValue = tag;
+                    const matcher = (doc) => {
+                        const docTags = tagsAccessor(doc.payload);
+                        return Array.isArray(docTags) && docTags.includes(tagValue);
+                    };
+                    this.createEventStream(streamName, matcher, false);
+                }
+            }
+        }
+    }
+
+    /**
      * @private
      * @param {object} event
      * @returns {string|null}
@@ -490,9 +542,10 @@ class EventStore extends events.EventEmitter {
             expectedVersion = ExpectedVersion.Any;
         }
 
-        // When typeAccessor is configured, ensure a dedicated type stream exists for each event
-        // before the entity stream write so the type stream index is never incomplete.
+        // When typeAccessor/tagsAccessor is configured, ensure dedicated streams exist for each
+        // event before the entity stream write so those indexes are never incomplete.
         this.ensureTypeStreams(events);
+        this.ensureTagStreams(events);
 
         if (!(streamName in this.streams)) {
             this.createEventStream(streamName, { stream: streamName }, false);
@@ -559,7 +612,8 @@ class EventStore extends events.EventEmitter {
      * in AND groups they collapse that branch to an empty result.
      *
      * @api
-     * @param {SelectorNode[]} selector A non-empty array of event types or a nested stream-selector algebra.
+     * @param {SelectorNode[]|object} selectorOrDcbQuery A non-empty selector array, or a {@link DcbQuery} object
+     *   with an `items` property (compiled automatically to selector algebra).
      * @param {function|object|null} [matcher] Optional matcher used for stream pre-filtering.
      *   In object mode, function predicates receive `(payload, metadata)`.
      * @param {number} [minRevision=1] The 1-based minimum global revision to include in the returned stream (inclusive).
@@ -571,7 +625,15 @@ class EventStore extends events.EventEmitter {
      *   `[[courseTag, ['CourseCreated', 'CourseCapacityChanged']], [studentTag, ['StudentCreated']]]`
      * @throws {Error} if `selector` is not a non-empty array.
      */
-    query(selector, matcher = null, minRevision = 1, raw = false) {
+    query(selectorOrDcbQuery, matcher = null, minRevision = 1, raw = false) {
+        let selector = selectorOrDcbQuery;
+        if (isDcbQuery(selectorOrDcbQuery)) {
+            selector = compileDcbQuery(
+                selectorOrDcbQuery,
+                (type) => this.resolveTypeStream(type),
+                (tag) => this.resolveTagStream(tag)
+            );
+        }
         assert(Array.isArray(selector) && selector.length > 0, 'Must specify a non-empty array of stream selectors for query.');
         // Normalize the selector once here; both the condition and the stream use
         // the normalized form.  Wrap a string result (single-stream reduction) in
@@ -581,6 +643,28 @@ class EventStore extends events.EventEmitter {
         const condition = new CommitCondition(querySelector, matcher, this.storage.length, raw);
         const stream = this.fromStreams('_query_' + Date.now(), querySelector, minRevision, -1, matcher, raw);
         return { stream, condition };
+    }
+
+    /**
+     * @private
+     * @param {string} type
+     * @returns {string} Stream name for the given event type.
+     * @throws {Error} When typeAccessor is not configured.
+     */
+    resolveTypeStream(type) {
+        assert(this.typeAccessor !== null, 'DcbQuery references "types" but typeAccessor not configured.');
+        return type;
+    }
+
+    /**
+     * @private
+     * @param {string} tag
+     * @returns {string} Stream name for the given tag value.
+     * @throws {Error} When tagsAccessor is not configured.
+     */
+    resolveTagStream(tag) {
+        assert(this.tagsAccessor !== null, 'DcbQuery references "tags" but tagsAccessor not configured.');
+        return 'tags/' + tag;
     }
 
     /**

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -6,7 +6,7 @@ import events from 'events';
 import Storage, { ReadOnly as ReadOnlyStorage, LOCK_THROW, LOCK_RECLAIM } from './Storage.js';
 import Index from './Index.js';
 import Consumer from './Consumer.js';
-import { assert, getPropertyAtPath } from './utils/util.js';
+import { assert, compileAccessor } from './utils/util.js';
 import { ensureDirectory, resolvePath, scanForFiles } from './utils/fsUtil.js';
 import { buildTypeMatcherFn } from './utils/metadataUtil.js';
 import { fixCommitArgumentTypes, parseStreamFromIndexName, normalizePredicateRaw } from './utils/apiHelpers.js';
@@ -116,20 +116,20 @@ class EventStore extends events.EventEmitter {
 
         if (config.typeAccessor) {
             assert(typeof config.typeAccessor === 'string', 'typeAccessor must be a dot-notation string path (e.g. \'type\').');
-            this.typeSource = { path: config.typeAccessor, nameBuilder: (v) => v, matcherFn: buildTypeMatcherFn(config.typeAccessor) };
+            this.typeSource = { path: config.typeAccessor, accessor: compileAccessor(config.typeAccessor), nameBuilder: (v) => v, matcherFn: buildTypeMatcherFn(config.typeAccessor) };
             this.streamSources.push(this.typeSource);
         }
 
         if (config.tagsAccessor) {
             assert(typeof config.tagsAccessor === 'string', 'tagsAccessor must be a dot-notation string path (e.g. \'tags\').');
-            this.tagsSource = { path: config.tagsAccessor, nameBuilder: (v) => `tags/${v}`, matcherFn: buildTypeMatcherFn(config.tagsAccessor) };
+            this.tagsSource = { path: config.tagsAccessor, accessor: compileAccessor(config.tagsAccessor), nameBuilder: (v) => `tags/${v}`, matcherFn: buildTypeMatcherFn(config.tagsAccessor) };
             this.streamSources.push(this.tagsSource);
         }
 
         for (const { path, nameBuilder } of config.streamSources ?? []) {
             assert(typeof path === 'string' && path, 'Each streamSources entry must have a non-empty string path.');
             assert(typeof nameBuilder === 'function', 'Each streamSources entry must have a nameBuilder function.');
-            this.streamSources.push({ path, nameBuilder, matcherFn: buildTypeMatcherFn(path) });
+            this.streamSources.push({ path, nameBuilder, accessor: compileAccessor(path), matcherFn: buildTypeMatcherFn(path) });
         }
 
         this.storageDirectory = resolvePath(config.storageDirectory || /* istanbul ignore next */ './data');
@@ -464,16 +464,16 @@ class EventStore extends events.EventEmitter {
      */
     ensureStreams(events) {
         if (this.streamSources.length === 0) return;
-        for (const source of this.streamSources) {
+        for (const { accessor, nameBuilder, matcherFn, path } of this.streamSources) {
             for (const event of events) {
-                const raw = getPropertyAtPath(event, source.path);
+                const raw = accessor(event);
                 const values = Array.isArray(raw) ? raw : (raw != null && raw !== '' ? [raw] : []);
                 for (const value of values) {
                     if (typeof value !== 'string' || !value) continue;
-                    const streamName = source.nameBuilder(value);
-                    assert(STREAM_NAME_PATTERN.test(streamName), `Invalid stream name "${streamName}" derived from path "${source.path}".`);
+                    const streamName = nameBuilder(value);
+                    assert(STREAM_NAME_PATTERN.test(streamName), `Invalid stream name "${streamName}" derived from path "${path}".`);
                     if (!(streamName in this.streams)) {
-                        this.createEventStream(streamName, source.matcherFn(value), false);
+                        this.createEventStream(streamName, matcherFn(value), false);
                     }
                 }
             }

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -8,9 +8,8 @@ import Index from './Index.js';
 import Consumer from './Consumer.js';
 import { assert, compileAccessor } from './utils/util.js';
 import { ensureDirectory, resolvePath, scanForFiles } from './utils/fsUtil.js';
-import { buildMatcherFn } from './utils/metadataUtil.js';
 import { fixCommitArgumentTypes, parseStreamFromIndexName, normalizePredicateRaw } from './utils/apiHelpers.js';
-import { normalizeSelector } from "./utils/indexUtil.js";
+import { normalizeSelector, buildStreamSource } from "./utils/indexUtil.js";
 import { isDcbQuery, compileDcbQuery } from "./utils/dcbUtil.js";
 
 const ExpectedVersion = {
@@ -25,26 +24,6 @@ const DEFAULT_MATCHER_PROPERTIES = ['stream', 'payload.type'];
 const STREAM_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_]*(?:[\/:@~+=\-#.][A-Za-z0-9_]+)*$/;
 const STORAGE_HOOK_EVENTS = new Set(['preCommit', 'preRead']);
 
-/**
- * Pre-compile a stream source descriptor with a single curried matcher factory:
- * `matcherFn(operator)(value) => objectMatcher`. The scalar and `$has` shapes are compiled
- * once per source so `ensureStreams` can pick the correct one based on the event property
- * type (scalar → no operator, array → `$has`) without rebuilding the closure per event.
- *
- * @param {string} sourcePath Dot-notation payload path (e.g. `'type'`, `'tags'`).
- * @param {function(string): string} nameBuilder Maps each source value to a stream name.
- * @returns {{path: string, accessor: function, nameBuilder: function, matcherFn: function(string|undefined): (function(any): object)}}
- */
-function buildStreamSource(sourcePath, nameBuilder) {
-    const scalarMatcher = buildMatcherFn(sourcePath);
-    const hasMatcher = buildMatcherFn(sourcePath, '$has');
-    return {
-        path: sourcePath,
-        accessor: compileAccessor(sourcePath),
-        nameBuilder,
-        matcherFn: (operator) => operator === '$has' ? hasMatcher : scalarMatcher
-    };
-}
 
 class OptimisticConcurrencyError extends Error {}
 

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -33,7 +33,7 @@ const STORAGE_HOOK_EVENTS = new Set(['preCommit', 'preRead']);
  *
  * @param {string} sourcePath Dot-notation payload path (e.g. `'type'`, `'tags'`).
  * @param {function(string): string} nameBuilder Maps each source value to a stream name.
- * @returns {{path: string, accessor: function, nameBuilder: function, matcherFn: function(string): (function(any): object)}}
+ * @returns {{path: string, accessor: function, nameBuilder: function, matcherFn: function(string|undefined): (function(any): object)}}
  */
 function buildStreamSource(sourcePath, nameBuilder) {
     const scalarMatcher = buildMatcherFn(sourcePath);

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -8,7 +8,7 @@ import Index from './Index.js';
 import Consumer from './Consumer.js';
 import { assert, compileAccessor } from './utils/util.js';
 import { ensureDirectory, resolvePath, scanForFiles } from './utils/fsUtil.js';
-import { buildTypeMatcherFn, buildTagMatcherFn } from './utils/metadataUtil.js';
+import { buildMatcherFn } from './utils/metadataUtil.js';
 import { fixCommitArgumentTypes, parseStreamFromIndexName, normalizePredicateRaw } from './utils/apiHelpers.js';
 import { normalizeSelector } from "./utils/indexUtil.js";
 import { isDcbQuery, compileDcbQuery } from "./utils/dcbUtil.js";
@@ -24,6 +24,27 @@ const ExpectedVersion = {
 const DEFAULT_MATCHER_PROPERTIES = ['stream', 'payload.type'];
 const STREAM_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_]*(?:[\/:@~+=\-#.][A-Za-z0-9_]+)*$/;
 const STORAGE_HOOK_EVENTS = new Set(['preCommit', 'preRead']);
+
+/**
+ * Pre-compile a stream source descriptor with a single curried matcher factory:
+ * `matcherFn(operator)(value) => objectMatcher`. The scalar and `$has` shapes are compiled
+ * once per source so `ensureStreams` can pick the correct one based on the event property
+ * type (scalar → no operator, array → `$has`) without rebuilding the closure per event.
+ *
+ * @param {string} sourcePath Dot-notation payload path (e.g. `'type'`, `'tags'`).
+ * @param {function(string): string} nameBuilder Maps each source value to a stream name.
+ * @returns {{path: string, accessor: function, nameBuilder: function, matcherFn: function(string): (function(any): object)}}
+ */
+function buildStreamSource(sourcePath, nameBuilder) {
+    const scalarMatcher = buildMatcherFn(sourcePath);
+    const hasMatcher = buildMatcherFn(sourcePath, '$has');
+    return {
+        path: sourcePath,
+        accessor: compileAccessor(sourcePath),
+        nameBuilder,
+        matcherFn: (operator) => operator === '$has' ? hasMatcher : scalarMatcher
+    };
+}
 
 class OptimisticConcurrencyError extends Error {}
 
@@ -116,20 +137,20 @@ class EventStore extends events.EventEmitter {
 
         if (config.typeAccessor) {
             assert(typeof config.typeAccessor === 'string', 'typeAccessor must be a dot-notation string path (e.g. \'type\').');
-            this.typeSource = { path: config.typeAccessor, accessor: compileAccessor(config.typeAccessor), nameBuilder: (v) => v, matcherFn: buildTypeMatcherFn(config.typeAccessor), tagMatcherFn: buildTagMatcherFn(config.typeAccessor) };
+            this.typeSource = buildStreamSource(config.typeAccessor, (v) => v);
             this.streamSources.push(this.typeSource);
         }
 
         if (config.tagsAccessor) {
             assert(typeof config.tagsAccessor === 'string', 'tagsAccessor must be a dot-notation string path (e.g. \'tags\').');
-            this.tagsSource = { path: config.tagsAccessor, accessor: compileAccessor(config.tagsAccessor), nameBuilder: (v) => `tags/${v}`, matcherFn: buildTypeMatcherFn(config.tagsAccessor), tagMatcherFn: buildTagMatcherFn(config.tagsAccessor) };
+            this.tagsSource = buildStreamSource(config.tagsAccessor, (v) => `tags/${v}`);
             this.streamSources.push(this.tagsSource);
         }
 
         for (const { path, nameBuilder } of config.streamSources ?? []) {
             assert(typeof path === 'string' && path, 'Each streamSources entry must have a non-empty string path.');
             assert(typeof nameBuilder === 'function', 'Each streamSources entry must have a nameBuilder function.');
-            this.streamSources.push({ path, nameBuilder, accessor: compileAccessor(path), matcherFn: buildTypeMatcherFn(path), tagMatcherFn: buildTagMatcherFn(path) });
+            this.streamSources.push(buildStreamSource(path, nameBuilder));
         }
 
         this.storageDirectory = resolvePath(config.storageDirectory || /* istanbul ignore next */ './data');
@@ -464,17 +485,17 @@ class EventStore extends events.EventEmitter {
      */
     ensureStreams(events) {
         if (this.streamSources.length === 0) return;
-        for (const { accessor, nameBuilder, matcherFn, tagMatcherFn, path } of this.streamSources) {
+        for (const { accessor, nameBuilder, matcherFn, path } of this.streamSources) {
             for (const event of events) {
                 const raw = accessor(event);
                 const isArrayValue = Array.isArray(raw);
                 const values = isArrayValue ? raw : (raw != null && raw !== '' ? [raw] : []);
+                const buildMatcher = matcherFn(isArrayValue ? '$has' : undefined);
                 for (const value of values) {
                     if (typeof value !== 'string' || !value) continue;
                     const streamName = nameBuilder(value);
                     assert(STREAM_NAME_PATTERN.test(streamName), `Invalid stream name "${streamName}" derived from path "${path}".`);
                     if (!(streamName in this.streams)) {
-                        const buildMatcher = isArrayValue ? tagMatcherFn : matcherFn;
                         this.createEventStream(streamName, buildMatcher(value), false);
                     }
                 }

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -116,8 +116,10 @@ class EventStore extends events.EventEmitter {
         if (typeof config.tagsAccessor === 'string' && config.tagsAccessor) {
             const accessorPath = config.tagsAccessor;
             this.tagsAccessor = (event) => getPropertyAtPath(event, accessorPath) ?? [];
+            this.tagsMatcherFn = buildTypeMatcherFn(accessorPath);
         } else {
             this.tagsAccessor = typeof config.tagsAccessor === 'function' ? config.tagsAccessor : null;
+            this.tagsMatcherFn = null;
         }
 
         this.storageDirectory = resolvePath(config.storageDirectory || /* istanbul ignore next */ './data');
@@ -129,11 +131,18 @@ class EventStore extends events.EventEmitter {
         };
         const storageConfig = Object.assign(defaults, config.storageConfig);
 
-        // When typeAccessor is a string path, ensure the corresponding full document path
-        // (payload.<path>) is present in matcherProperties so the IndexMatcher discriminant
-        // table can route type-stream lookups in O(1) on every write.
+        // When typeAccessor/tagsAccessor is a string path, ensure the corresponding full document
+        // path (payload.<path>) is in matcherProperties so the IndexMatcher discriminant table
+        // can route those stream lookups in O(1) on every write.
         if (this.typeMatcherFn) {
             const fullPath = `payload.${config.typeAccessor}`;
+            const currentProps = storageConfig.matcherProperties || DEFAULT_MATCHER_PROPERTIES;
+            if (!currentProps.includes(fullPath)) {
+                storageConfig.matcherProperties = [...currentProps, fullPath];
+            }
+        }
+        if (this.tagsMatcherFn) {
+            const fullPath = `payload.${config.tagsAccessor}`;
             const currentProps = storageConfig.matcherProperties || DEFAULT_MATCHER_PROPERTIES;
             if (!currentProps.includes(fullPath)) {
                 storageConfig.matcherProperties = [...currentProps, fullPath];
@@ -474,6 +483,7 @@ class EventStore extends events.EventEmitter {
     ensureTagStreams(events) {
         if (!this.tagsAccessor) return;
         const tagsAccessor = this.tagsAccessor;
+        const tagsMatcherFn = this.tagsMatcherFn;
         for (const event of events) {
             const tags = tagsAccessor(event);
             if (!Array.isArray(tags)) continue;
@@ -481,11 +491,15 @@ class EventStore extends events.EventEmitter {
                 if (typeof tag !== 'string' || !tag) continue;
                 const streamName = 'tags/' + tag;
                 if (!(streamName in this.streams)) {
-                    const tagValue = tag;
-                    const matcher = (doc) => {
-                        const docTags = tagsAccessor(doc.payload);
-                        return Array.isArray(docTags) && docTags.includes(tagValue);
-                    };
+                    // When tagsMatcherFn is set (string path form), build an object matcher so
+                    // IndexMatcher can classify it into the discriminant table for O(1) routing.
+                    // Fall back to a function matcher when tagsAccessor is a function.
+                    const matcher = tagsMatcherFn
+                        ? tagsMatcherFn(tag)
+                        : (doc) => {
+                            const docTags = tagsAccessor(doc.payload);
+                            return Array.isArray(docTags) && docTags.includes(tag);
+                        };
                     this.createEventStream(streamName, matcher, false);
                 }
             }

--- a/src/EventStore.js
+++ b/src/EventStore.js
@@ -84,14 +84,20 @@ class EventStore extends events.EventEmitter {
      * @param {string} [config.streamsDirectory] The directory where the streams should be stored. Default '{storageDirectory}/streams'.
      * @param {object} [config.storageConfig] Additional config options given to the storage backend. See `Storage`.
      * @param {boolean} [config.readOnly] If the storage should be mounted in read-only mode.
-     * @param {string|function(object): string} [config.typeAccessor] Dot-notation path (e.g. `'type'`) or
-     *   function `(event) => string` identifying the event type. Enables type-based queries via
-     *   {@link EventStore#query} and ensures proper index routing for those queries.
-     * @param {string|function(object): string[]} [config.tagsAccessor] Dot-notation path (e.g. `'tags'`) or
-     *   function `(event) => string[]` extracting tag values from an event payload on write. On each
-     *   {@link EventStore#commit}, one stream per tag is created under `tags/{tag}`. Enables tag-scoped
-     *   {@link DcbQuery} items via {@link EventStore#query}. Tag values are recommended to use `/` as a
-     *   hierarchy separator (e.g. `'course/jdsj4'` → stream `tags/course/jdsj4`).
+     * @param {Array<{path: string, nameBuilder: function(string): string}>} [config.streamSources] Generic
+     *   stream-index definitions. Each entry specifies a dot-notation `path` into the event payload and a
+     *   `nameBuilder(value) => streamName` function. On every {@link EventStore#commit} each entry is
+     *   evaluated: scalar values are passed directly to `nameBuilder`; array values are iterated so each
+     *   element produces its own stream. Non-string and empty values are skipped silently. The resulting
+     *   stream names must satisfy the stream-name pattern. Each entry's `path` is automatically registered
+     *   in `matcherProperties` for O(1) IndexMatcher routing.
+     * @param {string} [config.typeAccessor] Shorthand for a `streamSources` entry with `nameBuilder = v => v`.
+     *   Dot-notation path to the event type field (e.g. `'type'`). Enables type-based
+     *   {@link EventStore#query} selectors and {@link DcbQuery} `types` items.
+     * @param {string} [config.tagsAccessor] Shorthand for a `streamSources` entry with
+     *   `nameBuilder = v => \`tags/${v}\``. Dot-notation path to an array field of tag values (e.g.
+     *   `'tags'`). Enables tag-scoped {@link DcbQuery} `tags` items. Values are recommended to use `/`
+     *   as a hierarchy separator (e.g. `'course/jdsj4'` → stream `tags/course/jdsj4`).
      * @param {object|function(string): object} [config.streamMetadata] A metadata object or a function `(streamName) => object`
      *   that is called whenever a new stream partition is created. The returned object is stored once in the partition
      *   file header and surfaced to `preCommit` / `preRead` hooks. Takes precedence only when
@@ -104,22 +110,26 @@ class EventStore extends events.EventEmitter {
             storeName = 'eventstore';
         }
 
-        if (typeof config.typeAccessor === 'string' && config.typeAccessor) {
-            const accessorPath = config.typeAccessor;
-            this.typeAccessor = (event) => getPropertyAtPath(event, accessorPath);
-            this.typeMatcherFn = buildTypeMatcherFn(accessorPath);
-        } else {
-            this.typeAccessor = typeof config.typeAccessor === 'function' ? config.typeAccessor : null;
-            this.typeMatcherFn = null;
+        this.streamSources = [];
+        this.typeSource = null;
+        this.tagsSource = null;
+
+        if (config.typeAccessor) {
+            assert(typeof config.typeAccessor === 'string', 'typeAccessor must be a dot-notation string path (e.g. \'type\').');
+            this.typeSource = { path: config.typeAccessor, nameBuilder: (v) => v, matcherFn: buildTypeMatcherFn(config.typeAccessor) };
+            this.streamSources.push(this.typeSource);
         }
 
-        if (typeof config.tagsAccessor === 'string' && config.tagsAccessor) {
-            const accessorPath = config.tagsAccessor;
-            this.tagsAccessor = (event) => getPropertyAtPath(event, accessorPath) ?? [];
-            this.tagsMatcherFn = buildTypeMatcherFn(accessorPath);
-        } else {
-            this.tagsAccessor = typeof config.tagsAccessor === 'function' ? config.tagsAccessor : null;
-            this.tagsMatcherFn = null;
+        if (config.tagsAccessor) {
+            assert(typeof config.tagsAccessor === 'string', 'tagsAccessor must be a dot-notation string path (e.g. \'tags\').');
+            this.tagsSource = { path: config.tagsAccessor, nameBuilder: (v) => `tags/${v}`, matcherFn: buildTypeMatcherFn(config.tagsAccessor) };
+            this.streamSources.push(this.tagsSource);
+        }
+
+        for (const { path, nameBuilder } of config.streamSources ?? []) {
+            assert(typeof path === 'string' && path, 'Each streamSources entry must have a non-empty string path.');
+            assert(typeof nameBuilder === 'function', 'Each streamSources entry must have a nameBuilder function.');
+            this.streamSources.push({ path, nameBuilder, matcherFn: buildTypeMatcherFn(path) });
         }
 
         this.storageDirectory = resolvePath(config.storageDirectory || /* istanbul ignore next */ './data');
@@ -131,18 +141,10 @@ class EventStore extends events.EventEmitter {
         };
         const storageConfig = Object.assign(defaults, config.storageConfig);
 
-        // When typeAccessor/tagsAccessor is a string path, ensure the corresponding full document
-        // path (payload.<path>) is in matcherProperties so the IndexMatcher discriminant table
-        // can route those stream lookups in O(1) on every write.
-        if (this.typeMatcherFn) {
-            const fullPath = `payload.${config.typeAccessor}`;
-            const currentProps = storageConfig.matcherProperties || DEFAULT_MATCHER_PROPERTIES;
-            if (!currentProps.includes(fullPath)) {
-                storageConfig.matcherProperties = [...currentProps, fullPath];
-            }
-        }
-        if (this.tagsMatcherFn) {
-            const fullPath = `payload.${config.tagsAccessor}`;
+        // Register each source's payload path in matcherProperties so the IndexMatcher
+        // discriminant table can route stream lookups in O(1) on every write.
+        for (const source of this.streamSources) {
+            const fullPath = `payload.${source.path}`;
             const currentProps = storageConfig.matcherProperties || DEFAULT_MATCHER_PROPERTIES;
             if (!currentProps.includes(fullPath)) {
                 storageConfig.matcherProperties = [...currentProps, fullPath];
@@ -454,71 +456,28 @@ class EventStore extends events.EventEmitter {
     }
 
     /**
-     * Ensure a dedicated type stream exists for each event's type, creating it if needed.
-     * Must be called before the entity stream is created to guarantee correct index routing.
+     * Ensure a dedicated stream exists for each indexed property value across all stream sources.
+     * Must be called before the entity stream write so those indexes are never incomplete.
      *
      * @private
-     * @param {Array<object>} events The events to process.
+     * @param {Array<object>} events
      */
-    ensureTypeStreams(events) {
-        if (!this.typeAccessor) return;
-        for (const event of events) {
-            const type = this.resolveValidatedTypeStreamName(event);
-            if (type && !(type in this.streams)) {
-                const matcher = this.typeMatcherFn
-                    ? this.typeMatcherFn(type)
-                    : (doc) => this.typeAccessor(doc.payload) === type;
-                this.createEventStream(type, matcher, false);
-            }
-        }
-    }
-
-    /**
-     * Ensure a dedicated tag stream exists for each tag on each event, creating it if needed.
-     * Must be called before the entity stream is created (same ordering requirement as ensureTypeStreams).
-     *
-     * @private
-     * @param {Array<object>} events The events to process.
-     */
-    ensureTagStreams(events) {
-        if (!this.tagsAccessor) return;
-        const tagsAccessor = this.tagsAccessor;
-        const tagsMatcherFn = this.tagsMatcherFn;
-        for (const event of events) {
-            const tags = tagsAccessor(event);
-            if (!Array.isArray(tags)) continue;
-            for (const tag of tags) {
-                if (typeof tag !== 'string' || !tag) continue;
-                const streamName = 'tags/' + tag;
-                if (!(streamName in this.streams)) {
-                    // When tagsMatcherFn is set (string path form), build an object matcher so
-                    // IndexMatcher can classify it into the discriminant table for O(1) routing.
-                    // Fall back to a function matcher when tagsAccessor is a function.
-                    const matcher = tagsMatcherFn
-                        ? tagsMatcherFn(tag)
-                        : (doc) => {
-                            const docTags = tagsAccessor(doc.payload);
-                            return Array.isArray(docTags) && docTags.includes(tag);
-                        };
-                    this.createEventStream(streamName, matcher, false);
+    ensureStreams(events) {
+        if (this.streamSources.length === 0) return;
+        for (const source of this.streamSources) {
+            for (const event of events) {
+                const raw = getPropertyAtPath(event, source.path);
+                const values = Array.isArray(raw) ? raw : (raw != null && raw !== '' ? [raw] : []);
+                for (const value of values) {
+                    if (typeof value !== 'string' || !value) continue;
+                    const streamName = source.nameBuilder(value);
+                    assert(STREAM_NAME_PATTERN.test(streamName), `Invalid stream name "${streamName}" derived from path "${source.path}".`);
+                    if (!(streamName in this.streams)) {
+                        this.createEventStream(streamName, source.matcherFn(value), false);
+                    }
                 }
             }
         }
-    }
-
-    /**
-     * @private
-     * @param {object} event
-     * @returns {string|null}
-     */
-    resolveValidatedTypeStreamName(event) {
-        const type = this.typeAccessor(event);
-        if (type === undefined || type === null || type === '') {
-            return null;
-        }
-        assert(typeof type === 'string', 'typeAccessor must return a string.');
-        assert(STREAM_NAME_PATTERN.test(type), `typeAccessor must return a valid stream name. Got: "${type}"`);
-        return type;
     }
 
     /**
@@ -556,10 +515,8 @@ class EventStore extends events.EventEmitter {
             expectedVersion = ExpectedVersion.Any;
         }
 
-        // When typeAccessor/tagsAccessor is configured, ensure dedicated streams exist for each
-        // event before the entity stream write so those indexes are never incomplete.
-        this.ensureTypeStreams(events);
-        this.ensureTagStreams(events);
+        // Ensure all indexed streams exist before the entity stream write so those indexes are never incomplete.
+        this.ensureStreams(events);
 
         if (!(streamName in this.streams)) {
             this.createEventStream(streamName, { stream: streamName }, false);
@@ -666,8 +623,8 @@ class EventStore extends events.EventEmitter {
      * @throws {Error} When typeAccessor is not configured.
      */
     resolveTypeStream(type) {
-        assert(this.typeAccessor !== null, 'DcbQuery references "types" but typeAccessor not configured.');
-        return type;
+        assert(this.typeSource !== null, 'DcbQuery references "types" but typeAccessor not configured.');
+        return this.typeSource.nameBuilder(type);
     }
 
     /**
@@ -677,8 +634,8 @@ class EventStore extends events.EventEmitter {
      * @throws {Error} When tagsAccessor is not configured.
      */
     resolveTagStream(tag) {
-        assert(this.tagsAccessor !== null, 'DcbQuery references "tags" but tagsAccessor not configured.');
-        return 'tags/' + tag;
+        assert(this.tagsSource !== null, 'DcbQuery references "tags" but tagsAccessor not configured.');
+        return this.tagsSource.nameBuilder(tag);
     }
 
     /**

--- a/src/IndexMatcher.js
+++ b/src/IndexMatcher.js
@@ -2,6 +2,18 @@ import { getPropertyAtPath } from './utils/util.js';
 import { matches } from './utils/metadataUtil.js';
 
 /**
+ * @param {any} value Candidate matcher value at a discriminant path.
+ * @returns {boolean} True when `value` is `{ $has: scalar }` (lone $has with a non-object value).
+ */
+function isLoneHasScalar(value) {
+    if (Array.isArray(value)) return false;
+    const keys = Object.keys(value);
+    if (keys.length !== 1 || keys[0] !== '$has') return false;
+    const has = value.$has;
+    return has !== null && has !== undefined && typeof has !== 'object';
+}
+
+/**
  * @typedef {object|function(object):boolean} Matcher
  */
 
@@ -217,6 +229,11 @@ class IndexMatcher {
                 if (Array.isArray(value) && value.length > 0 &&
                     value.every(v => v !== null && v !== undefined && typeof v !== 'object')) {
                     return { propPath, values: value.map(String) };
+                }
+                // Lone $has operator: array-containment matcher (e.g. tag streams). Treat the
+                // has-value as the discriminant so array-valued documents route in O(1).
+                if (isLoneHasScalar(value)) {
+                    return { propPath, values: [String(value.$has)] };
                 }
             }
         }

--- a/src/IndexMatcher.js
+++ b/src/IndexMatcher.js
@@ -143,7 +143,30 @@ class IndexMatcher {
 
         for (const propPath of this.properties) {
             const docValue = getPropertyAtPath(document, propPath);
-            if (docValue === undefined || docValue === null || typeof docValue === 'object') {
+            if (docValue === undefined || docValue === null) {
+                continue;
+            }
+
+            if (Array.isArray(docValue)) {
+                // Multi-value document property: each array element is a potential discriminant.
+                // A dedup set prevents calling iterationHandler twice when two elements map to
+                // the same index (e.g. duplicate tags, or a single index registered for both).
+                const called = new Set();
+                for (const item of docValue) {
+                    if (item === null || item === undefined || typeof item === 'object') continue;
+                    const indexSet = this.table.get(propPath)?.get(String(item));
+                    if (!indexSet) continue;
+                    for (const indexName of indexSet) {
+                        if (!called.has(indexName) && matches(document, this.matchers.get(indexName))) {
+                            called.add(indexName);
+                            iterationHandler(indexName);
+                        }
+                    }
+                }
+                continue;
+            }
+
+            if (typeof docValue === 'object') {
                 continue;
             }
 

--- a/src/utils/dcbUtil.js
+++ b/src/utils/dcbUtil.js
@@ -24,7 +24,7 @@ function isDcbQuery(value) {
  */
 function compileDcbQuery(query, resolveType, resolveTag) {
     if (!Array.isArray(query.items) || query.items.length === 0) {
-        throw new Error("DcbQuery.items must be a non-empty array. Use getEventStream('_all') for an unconstrained read.");
+        throw new Error("DcbQuery.items must be a non-empty array. Use ['_all'] for an unconstrained read.");
     }
     return query.items.map(item => compileDcbItem(item, resolveType, resolveTag));
 }
@@ -63,7 +63,7 @@ function compileDcbItem(item, resolveType, resolveTag) {
     }
 
     if (terms.length === 0) return '_all';
-    if (terms.length === 1) return terms[0];
+    if (terms.length === 1 && typeof terms[0] === 'string') return terms[0];
     return terms; // inner array = AND level
 }
 

--- a/src/utils/dcbUtil.js
+++ b/src/utils/dcbUtil.js
@@ -1,0 +1,70 @@
+/**
+ * Determine whether a value is a DcbQuery object (plain object with an `items` property).
+ *
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isDcbQuery(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value) && 'items' in value;
+}
+
+/**
+ * Compile a {@link DcbQuery} into a selector-algebra array suitable for JoinEventStream.
+ *
+ * Each item in `query.items` produces one sub-selector (OR at the top level).
+ * Within an item, tags and types are combined with AND semantics; multiple types form a nested OR.
+ *
+ * @param {object} query - Object with a non-empty `items` array.
+ * @param {function(string): string} resolveType - Maps a type name to its stream name. Throws when
+ *   `typeAccessor` is not configured.
+ * @param {function(string): string} resolveTag - Maps a tag value to its namespaced stream name
+ *   (e.g. `'tags/' + tag`). Throws when `tagsAccessor` is not configured.
+ * @returns {Array} Selector-algebra array (non-empty).
+ * @throws {Error} When `items` is missing, null, or empty.
+ */
+function compileDcbQuery(query, resolveType, resolveTag) {
+    if (!Array.isArray(query.items) || query.items.length === 0) {
+        throw new Error("DcbQuery.items must be a non-empty array. Use getEventStream('_all') for an unconstrained read.");
+    }
+    return query.items.map(item => compileDcbItem(item, resolveType, resolveTag));
+}
+
+/**
+ * Compile a single DcbQuery item into a sub-selector.
+ *
+ * An item with no constraints (empty/missing `types` and `tags`) compiles to `'_all'`.
+ * Explicit `null` on `types` or `tags` throws — it is almost always a programming error.
+ *
+ * @param {object} item - QueryItem with optional `types: string[]` and `tags: string[]`.
+ * @param {function(string): string} resolveType
+ * @param {function(string): string} resolveTag
+ * @returns {string|Array} Sub-selector for this item.
+ * @throws {Error} When item is null/undefined, or when `types`/`tags` is non-null and non-array.
+ */
+function compileDcbItem(item, resolveType, resolveTag) {
+    if (item === null || item === undefined) {
+        throw new Error('DcbQuery item must be an object, got ' + item);
+    }
+    if (item.tags !== undefined && !Array.isArray(item.tags)) {
+        throw new Error('DcbQuery item.tags must be an array or undefined, got ' + typeof item.tags);
+    }
+    if (item.types !== undefined && !Array.isArray(item.types)) {
+        throw new Error('DcbQuery item.types must be an array or undefined, got ' + typeof item.types);
+    }
+
+    const terms = [];
+
+    for (const tag of item.tags ?? []) {
+        terms.push(resolveTag(tag));
+    }
+    if (item.types?.length) {
+        const typeStreams = item.types.map(resolveType);
+        terms.push(typeStreams.length === 1 ? typeStreams[0] : typeStreams);
+    }
+
+    if (terms.length === 0) return '_all';
+    if (terms.length === 1) return terms[0];
+    return terms; // inner array = AND level
+}
+
+export {isDcbQuery, compileDcbQuery};

--- a/src/utils/indexUtil.js
+++ b/src/utils/indexUtil.js
@@ -196,13 +196,6 @@ function optimizeSelectorNode(selectorNode, depth) {
     return selectorNode;
 }
 
-export {
-    union,
-    intersect,
-    normalizeSelector,
-    buildStreamSource
-};
-
 /**
  * Pre-compile a stream source descriptor with a single curried matcher factory:
  * `matcherFn(operator)(value) => objectMatcher`. The scalar and `$has` shapes are compiled
@@ -223,3 +216,10 @@ function buildStreamSource(sourcePath, nameBuilder) {
         matcherFn: (operator) => operator === '$has' ? hasMatcher : scalarMatcher
     };
 }
+
+export {
+    union,
+    intersect,
+    normalizeSelector,
+    buildStreamSource
+};

--- a/src/utils/indexUtil.js
+++ b/src/utils/indexUtil.js
@@ -1,4 +1,5 @@
-import { assert } from './util.js';
+import { assert, compileAccessor } from './util.js';
+import { buildMatcherFn } from './metadataUtil.js';
 
 /**
  * Merge two sorted index-entry ranges into one sorted union without duplicates.
@@ -198,5 +199,27 @@ function optimizeSelectorNode(selectorNode, depth) {
 export {
     union,
     intersect,
-    normalizeSelector
+    normalizeSelector,
+    buildStreamSource
 };
+
+/**
+ * Pre-compile a stream source descriptor with a single curried matcher factory:
+ * `matcherFn(operator)(value) => objectMatcher`. The scalar and `$has` shapes are compiled
+ * once per source so callers can pick the correct one based on the event property type
+ * (scalar → no operator, array → `$has`) without rebuilding the closure per event.
+ *
+ * @param {string} sourcePath Dot-notation payload path (e.g. `'type'`, `'tags'`).
+ * @param {function(string): string} nameBuilder Maps each source value to a stream name.
+ * @returns {{path: string, accessor: function, nameBuilder: function, matcherFn: function(string|undefined): (function(any): object)}}
+ */
+function buildStreamSource(sourcePath, nameBuilder) {
+    const scalarMatcher = buildMatcherFn(sourcePath);
+    const hasMatcher = buildMatcherFn(sourcePath, '$has');
+    return {
+        path: sourcePath,
+        accessor: compileAccessor(sourcePath),
+        nameBuilder,
+        matcherFn: (operator) => operator === '$has' ? hasMatcher : scalarMatcher
+    };
+}

--- a/src/utils/metadataUtil.js
+++ b/src/utils/metadataUtil.js
@@ -221,35 +221,22 @@ function buildMatcherFromMetadata(matcherMetadata, hmac) {
 }
 
 /**
- * Builds a factory function that, given a type string, returns an object matcher for
- * documents whose payload contains that type at the given dot-notation path.
+ * Builds a factory function that, given a scalar value, returns an object matcher targeting
+ * the given dot-notation payload path. Without an operator (or with `'$eq'`) the leaf is a
+ * plain scalar equality check; with an operator like `'$has'` the leaf is wrapped as
+ * `{[operator]: value}` so array-containment or other single-operator checks are produced.
  *
- * @param {string} payloadPath Dot-notation path relative to the event payload (e.g. `'type'`, `'meta.kind'`).
- * @returns {function(string): object} A function `(typeValue) => objectMatcher`.
+ * @param {string} payloadPath Dot-notation path relative to the event payload (e.g. `'type'`, `'tags'`).
+ * @param {string} [operator] Optional matcher operator (e.g. `'$has'`). Missing or `'$eq'` produces a scalar matcher.
+ * @returns {function(any): object} A function `(value) => objectMatcher`.
  */
-function buildTypeMatcherFn(payloadPath) {
+function buildMatcherFn(payloadPath, operator) {
     const parts = payloadPath.split('.');
-    return function (typeValue) {
-        let obj = typeValue;
-        for (let i = parts.length - 1; i >= 0; i--) {
-            obj = {[parts[i]]: obj};
-        }
-        return {payload: obj};
-    };
-}
-
-/**
- * Like {@link buildTypeMatcherFn} but wraps the leaf value in a `$has` operator so the resulting
- * object matcher performs an array-containment check. Use this for stream sources whose payload
- * field is an array of tag values (each element identifies a stream).
- *
- * @param {string} payloadPath Dot-notation path relative to the event payload (e.g. `'tags'`).
- * @returns {function(string): object} A function `(tagValue) => objectMatcher` producing `{payload: {…: {$has: tagValue}}}`.
- */
-function buildTagMatcherFn(payloadPath) {
-    const parts = payloadPath.split('.');
-    return function (tagValue) {
-        let obj = {$has: tagValue};
+    const wrapLeaf = (!operator || operator === '$eq')
+        ? (value) => value
+        : (value) => ({[operator]: value});
+    return function (value) {
+        let obj = wrapLeaf(value);
         for (let i = parts.length - 1; i >= 0; i--) {
             obj = {[parts[i]]: obj};
         }
@@ -353,8 +340,8 @@ function buildMatcherTreeChild(key, value) {
             // at the array's element level (skipping nested objects/arrays).
             child.isKeyPattern = true;
             child.pattern = Buffer.concat([keyPrefix, Buffer.from('[', 'utf8')]);
-            const hasPattern = Buffer.from(JSON.stringify(value['$has']), 'utf8');
-            child.matches = (buffer, valueStart) => indexOfSameLevel(buffer, hasPattern, valueStart) !== -1;
+            const valuePattern = Buffer.from(JSON.stringify(value['$has']), 'utf8');
+            child.matches = (buffer, valueStart) => indexOfSameLevel(buffer, valuePattern, valueStart) !== -1;
         } else if (isOperatorObject(value)) {
             child.isKeyPattern = true;
             child.pattern = keyPrefix;
@@ -542,7 +529,6 @@ export {
     buildMetadataHeader,
     buildMetadataForMatcher,
     buildMatcherFromMetadata,
-    buildTypeMatcherFn,
-    buildTagMatcherFn,
+    buildMatcherFn,
     buildRawBufferMatcher
 };

--- a/src/utils/metadataUtil.js
+++ b/src/utils/metadataUtil.js
@@ -54,11 +54,6 @@ function propertyMatchesValue(documentValue, matcherValue) {
         }
         return matches(documentValue, matcherValue);
     }
-    // Array document value with scalar matcher: treat as containment check.
-    // e.g. matches({ tags: ['a', 'b'] }, { tags: 'a' }) → true
-    if (Array.isArray(documentValue)) {
-        return documentValue.includes(matcherValue);
-    }
     return typeof matcherValue === 'undefined' || documentValue === matcherValue;
 }
 
@@ -90,6 +85,9 @@ function buildOperatorChecks(operatorObj) {
                 break;
             case '$ne':
                 checks.push(value => value !== expectedValue);
+                break;
+            case '$has':
+                checks.push(value => Array.isArray(value) && value.includes(expectedValue));
                 break;
             default:
                 throw new TypeError(`Unknown operator: ${operator}`);
@@ -241,6 +239,25 @@ function buildTypeMatcherFn(payloadPath) {
 }
 
 /**
+ * Like {@link buildTypeMatcherFn} but wraps the leaf value in a `$has` operator so the resulting
+ * object matcher performs an array-containment check. Use this for stream sources whose payload
+ * field is an array of tag values (each element identifies a stream).
+ *
+ * @param {string} payloadPath Dot-notation path relative to the event payload (e.g. `'tags'`).
+ * @returns {function(string): object} A function `(tagValue) => objectMatcher` producing `{payload: {…: {$has: tagValue}}}`.
+ */
+function buildTagMatcherFn(payloadPath) {
+    const parts = payloadPath.split('.');
+    return function (tagValue) {
+        let obj = {$has: tagValue};
+        for (let i = parts.length - 1; i >= 0; i--) {
+            obj = {[parts[i]]: obj};
+        }
+        return {payload: obj};
+    };
+}
+
+/**
  * Compile an object matcher into a raw-buffer predicate so raw-mode reads can filter compact
  * JSON without parsing every document first.
  *
@@ -330,6 +347,14 @@ function buildMatcherTreeChild(key, value) {
             child.pattern = keyPrefix;
             const nePattern = [Buffer.from(JSON.stringify(value['$ne']), 'utf8')];
             child.matches = (buffer, valueStart) => !matchesAnyValuePattern(buffer, valueStart, nePattern);
+        } else if ('$has' in value && Object.keys(value).length === 1) {
+            // A lone $has is a same-level array-containment check. The pattern locates the array
+            // opener (`"key":[`) and the follow-up scans array elements for the serialized scalar
+            // at the array's element level (skipping nested objects/arrays).
+            child.isKeyPattern = true;
+            child.pattern = Buffer.concat([keyPrefix, Buffer.from('[', 'utf8')]);
+            const hasPattern = Buffer.from(JSON.stringify(value['$has']), 'utf8');
+            child.matches = (buffer, valueStart) => indexOfSameLevel(buffer, hasPattern, valueStart) !== -1;
         } else if (isOperatorObject(value)) {
             child.isKeyPattern = true;
             child.pattern = keyPrefix;
@@ -518,5 +543,6 @@ export {
     buildMetadataForMatcher,
     buildMatcherFromMetadata,
     buildTypeMatcherFn,
+    buildTagMatcherFn,
     buildRawBufferMatcher
 };

--- a/src/utils/metadataUtil.js
+++ b/src/utils/metadataUtil.js
@@ -54,6 +54,11 @@ function propertyMatchesValue(documentValue, matcherValue) {
         }
         return matches(documentValue, matcherValue);
     }
+    // Array document value with scalar matcher: treat as containment check.
+    // e.g. matches({ tags: ['a', 'b'] }, { tags: 'a' }) → true
+    if (Array.isArray(documentValue)) {
+        return documentValue.includes(matcherValue);
+    }
     return typeof matcherValue === 'undefined' || documentValue === matcherValue;
 }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -192,6 +192,28 @@ function getPropertyAtPath(obj, dotPath) {
     return current;
 }
 
+/**
+ * Compiles a dot-notation path string into a reusable accessor function,
+ * avoiding repeated string splitting and iteration on every call.
+ *
+ * @param {string} dotPath
+ * @returns {function(object): *}
+ */
+function compileAccessor(dotPath) {
+    const parts = dotPath.split('.');
+    if (parts.length === 1) {
+        return (obj) => obj == null ? undefined : obj[dotPath];
+    }
+    return (obj) => {
+        let cur = obj;
+        for (const part of parts) {
+            if (cur == null || typeof cur !== 'object') return undefined;
+            cur = cur[part];
+        }
+        return cur;
+    };
+}
+
 export {
     assert,
     assertEqual,
@@ -201,5 +223,6 @@ export {
     binarySearch,
     alignTo,
     kWayMerge,
-    getPropertyAtPath
+    getPropertyAtPath,
+    compileAccessor
 };

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -1949,7 +1949,7 @@ describe('EventStore', function() {
         });
 
         it('returns a condition and a stream', function() {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const { condition, stream } = eventstore.query(['OrderPlaced']);
             expect(condition).to.be.a(CommitCondition);
             expect(condition.selector).to.eql(['OrderPlaced']);
@@ -1958,7 +1958,7 @@ describe('EventStore', function() {
         });
 
         it('captures the current store length as condition.noneMatchAfter', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'OrderPlaced', id: 1 }], () => {
                 const { condition } = eventstore.query(['OrderPlaced', 'OrderShipped']);
                 expect(condition.noneMatchAfter).to.be(1);
@@ -1967,7 +1967,7 @@ describe('EventStore', function() {
         });
 
         it('returns a joined stream over multiple types', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('s', [{ type: 'A', n: 1 }], () => {
                 eventstore.commit('s', [{ type: 'B', n: 2 }], () => {
                     const { stream } = eventstore.query(['A', 'B']);
@@ -1978,7 +1978,7 @@ describe('EventStore', function() {
         });
 
         it('the stream for a single type is a plain EventStream', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('s', [{ type: 'A', n: 1 }], () => {
                 const { stream } = eventstore.query(['A']);
                 const evs = stream.events;
@@ -1989,7 +1989,7 @@ describe('EventStore', function() {
         });
 
         it('pre-filters the stream by the matcher function', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 'abc' }], () => {
                 eventstore.commit('order-2', [{ type: 'OrderPlaced', orderId: 'xyz' }], () => {
                     const { stream } = eventstore.query(['OrderPlaced'], (payload) => payload.orderId === 'abc');
@@ -2001,7 +2001,7 @@ describe('EventStore', function() {
         });
 
         it('causes an OCC error when a matched event appeared since the condition', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const { condition } = eventstore.query(['OrderPlaced'], (payload) => payload.orderId === 'abc');
             eventstore.commit('order-abc', [{ type: 'OrderPlaced', orderId: 'abc' }], () => {
                 expect(() => eventstore.commit('order-2', [{ type: 'OrderShipped', id: 2 }], condition))
@@ -2011,7 +2011,7 @@ describe('EventStore', function() {
         });
 
         it('passes payload and metadata as separate arguments to the matcher', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             let receivedPayload, receivedMetadata;
             eventstore.commit('s', [{ type: 'A', val: 42 }], () => {
                 const { stream } = eventstore.query(['A'], (payload, metadata) => {
@@ -2032,18 +2032,18 @@ describe('EventStore', function() {
         });
 
         it('does not throw when a type stream does not exist and typeAccessor is configured', function() {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             expect(() => eventstore.query(['OrderPlaced'])).to.not.throwError();
         });
 
         it('returns an empty stream for types with no committed events when typeAccessor is configured', function() {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const { stream } = eventstore.query(['OrderPlaced']);
             expect(stream.events.length).to.be(0);
         });
 
         it('supports raw mode and object matcher', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 'a' }], () => {
                 eventstore.commit('order-2', [{ type: 'OrderPlaced', orderId: 'b' }], () => {
                     const { stream, condition } = eventstore.query(
@@ -2063,7 +2063,7 @@ describe('EventStore', function() {
         });
 
         it('stores function matcher and raw flag for raw-mode function matchers', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 'a' }], () => {
                 eventstore.commit('order-2', [{ type: 'OrderPlaced', orderId: 'b' }], () => {
                     const matcher = (buffer) => buffer.includes(Buffer.from('"orderId":"b"', 'utf8'));
@@ -2090,7 +2090,7 @@ describe('EventStore', function() {
     describe('commit with CommitCondition', function() {
 
         it('commits successfully when no events appeared since the condition', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'OrderPlaced', id: 1 }], () => {
                 const { condition } = eventstore.query(['OrderPlaced']);
                 expect(() => eventstore.commit('order-2', [{ type: 'OrderShipped', id: 2 }], condition)).to.not.throwError();
@@ -2099,7 +2099,7 @@ describe('EventStore', function() {
         });
 
         it('throws when a new event of the type appeared since the condition (no matcher)', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const { condition } = eventstore.query(['OrderPlaced']);
             eventstore.commit('order-1', [{ type: 'OrderPlaced', id: 1 }], () => {
                 expect(() => eventstore.commit('order-2', [{ type: 'OrderShipped', id: 2 }], condition))
@@ -2109,7 +2109,7 @@ describe('EventStore', function() {
         });
 
         it('does not throw when new events do not match the condition matcher', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const matcher = (payload) => payload.orderId === 'xyz';
             const { condition } = eventstore.query(['OrderPlaced'], matcher);
             // Commit an OrderPlaced for a DIFFERENT order — should not conflict.
@@ -2121,7 +2121,7 @@ describe('EventStore', function() {
         });
 
         it('throws when a new event matches the condition matcher', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const matcher = (payload) => payload.orderId === 'xyz';
             const { condition } = eventstore.query(['OrderPlaced'], matcher);
             // Commit an OrderPlaced for the SAME order — should conflict.
@@ -2133,7 +2133,7 @@ describe('EventStore', function() {
         });
 
         it('accepts a condition together with a callback', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const { condition } = eventstore.query(['OrderPlaced']);
             eventstore.commit('s', [{ type: 'OrderShipped' }], condition, (commit) => {
                 expect(commit.streamName).to.be('s');
@@ -2142,7 +2142,7 @@ describe('EventStore', function() {
         });
 
         it('accepts a condition together with metadata and a callback', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const { condition } = eventstore.query(['OrderPlaced']);
             eventstore.commit('s', [{ type: 'OrderShipped' }], condition, { extra: 'meta' }, (commit) => {
                 expect(commit.extra).to.be('meta');
@@ -2157,65 +2157,37 @@ describe('EventStore', function() {
     // -------------------------------------------------------------------------
     describe('typeAccessor', function() {
 
-        describe('string path form', function() {
+        it('throws when typeAccessor is a function', function() {
+            expect(() => new EventStore({ storageDirectory, typeAccessor: (event) => event.type }))
+                .to.throwError(/typeAccessor must be a dot-notation string path/);
+        });
 
-            it('creates a type stream lazily on first commit', function(done) {
-                eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
-                expect(eventstore.getStreamVersion('OrderPlaced')).to.be(-1);
-                eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 1 }], () => {
-                    expect(eventstore.getStreamVersion('OrderPlaced')).to.be(1);
-                    done();
-                });
+        it('supports nested dot-notation path (e.g. meta.kind)', function(done) {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'meta.kind' });
+            eventstore.commit('order-1', [{ meta: { kind: 'OrderPlaced' }, orderId: 7 }], () => {
+                expect(eventstore.getStreamVersion('OrderPlaced')).to.be(1);
+                const { stream } = eventstore.query(['OrderPlaced']);
+                expect(stream.events.length).to.be(1);
+                expect(stream.events[0].orderId).to.be(7);
+                done();
             });
+        });
 
-            it('query() returns events once the type has been committed', function(done) {
-                eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
-                eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 42 }], () => {
-                    const { stream } = eventstore.query(['OrderPlaced']);
-                    expect(stream.events.length).to.be(1);
-                    expect(stream.events[0].orderId).to.be(42);
-                    done();
-                });
-            });
+        it('auto-adds the accessor path to matcherProperties so type-stream matchers get discriminant routing', function() {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'eventKind' });
+            const props = eventstore.storage.indexMatcher.properties;
+            expect(props).to.contain('payload.eventKind');
+        });
 
-            it('silently skips type stream creation when accessor path resolves to falsy', function(done) {
-                eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
-                eventstore.commit('s', [{ noType: true }], () => {
-                    expect(Object.keys(eventstore.streams).filter(name => !name.startsWith('_'))).to.eql(['s']);
-                    done();
-                });
-            });
-
-            it('supports nested dot-notation path (e.g. meta.kind)', function(done) {
-                eventstore = new EventStore({ storageDirectory, typeAccessor: 'meta.kind' });
-                eventstore.commit('order-1', [{ meta: { kind: 'OrderPlaced' }, orderId: 7 }], () => {
-                    expect(eventstore.getStreamVersion('OrderPlaced')).to.be(1);
-                    const { stream } = eventstore.query(['OrderPlaced']);
-                    expect(stream.events.length).to.be(1);
-                    expect(stream.events[0].orderId).to.be(7);
-                    done();
-                });
-            });
-
-            it('auto-adds the accessor path to matcherProperties so type-stream matchers get discriminant routing', function() {
-                eventstore = new EventStore({ storageDirectory, typeAccessor: 'eventKind' });
-                // 'payload.eventKind' is not in the default list, so it must have been injected.
-                const props = eventstore.storage.indexMatcher.properties;
-                expect(props).to.contain('payload.eventKind');
-            });
-
-            it('does not duplicate the path when it is already in matcherProperties', function() {
-                eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
-                // 'payload.type' is already in the default list — must not appear twice.
-                const props = eventstore.storage.indexMatcher.properties;
-                const count = props.filter(p => p === 'payload.type').length;
-                expect(count).to.be(1);
-            });
-
+        it('does not duplicate the path when it is already in matcherProperties', function() {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
+            const props = eventstore.storage.indexMatcher.properties;
+            const count = props.filter(p => p === 'payload.type').length;
+            expect(count).to.be(1);
         });
 
         it('creates a type stream lazily on first commit', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             expect(eventstore.getStreamVersion('OrderPlaced')).to.be(-1);
             eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 1 }], () => {
                 expect(eventstore.getStreamVersion('OrderPlaced')).to.be(1);
@@ -2224,7 +2196,7 @@ describe('EventStore', function() {
         });
 
         it('accepts dotted type stream names when they match the stream-name rules', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'Order.Placed', orderId: 1 }], () => {
                 expect(eventstore.getStreamVersion('Order.Placed')).to.be(1);
                 done();
@@ -2232,7 +2204,7 @@ describe('EventStore', function() {
         });
 
         it('creates type streams for all event types in a multi-event commit', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [
                 { type: 'OrderPlaced', orderId: 1 },
                 { type: 'OrderShipped', orderId: 1 }
@@ -2243,20 +2215,22 @@ describe('EventStore', function() {
             });
         });
 
-        it('throws when typeAccessor returns a non-string value', function() {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
-            expect(() => eventstore.commit('s', [{ type: 42 }])).to.throwError(/typeAccessor must return a string/);
-            expect(eventstore.length).to.be(0);
+        it('silently skips type stream creation when typeAccessor path resolves to a non-string value', function(done) {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
+            eventstore.commit('s', [{ type: 42 }], () => {
+                expect(Object.keys(eventstore.streams).filter(n => !n.startsWith('_'))).to.eql(['s']);
+                done();
+            });
         });
 
         it('throws when typeAccessor returns a string that is not a valid stream name', function() {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
-            expect(() => eventstore.commit('s', [{ type: 'Order..Placed' }])).to.throwError(/typeAccessor must return a valid stream name/);
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
+            expect(() => eventstore.commit('s', [{ type: 'Order..Placed' }])).to.throwError(/Invalid stream name/);
             expect(eventstore.length).to.be(0);
         });
 
         it('silently skips type stream creation when typeAccessor returns a falsy value', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('s', [{ noType: true }], () => {
                 // Only the entity stream 's' should have been created; no type stream
                 expect(eventstore.getStreamVersion('s')).to.be(1);
@@ -2267,18 +2241,18 @@ describe('EventStore', function() {
         });
 
         it('query() does not throw for missing type streams when typeAccessor is configured', function() {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             expect(() => eventstore.query(['OrderPlaced'])).to.not.throwError();
         });
 
         it('query() returns an empty stream when typeAccessor is configured but type not yet committed', function() {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             const { stream } = eventstore.query(['OrderPlaced']);
             expect(stream.events.length).to.be(0);
         });
 
         it('query() returns events once the type has been committed', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 42 }], () => {
                 const { stream } = eventstore.query(['OrderPlaced']);
                 expect(stream.events.length).to.be(1);
@@ -2288,7 +2262,7 @@ describe('EventStore', function() {
         });
 
         it('query() returns events in insertion order across multiple type streams', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'A', n: 1 }], () => {
                 eventstore.commit('order-2', [{ type: 'B', n: 2 }], () => {
                     eventstore.commit('order-1', [{ type: 'A', n: 3 }], () => {
@@ -2301,7 +2275,7 @@ describe('EventStore', function() {
         });
 
         it('query() stream is pre-filtered by the matcher', function(done) {
-            eventstore = new EventStore({ storageDirectory, typeAccessor: (event) => event.type });
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
             eventstore.commit('order-1', [{ type: 'OrderPlaced', orderId: 'abc' }], () => {
                 eventstore.commit('order-2', [{ type: 'OrderPlaced', orderId: 'xyz' }], () => {
                     const { stream } = eventstore.query(['OrderPlaced'], (payload) => payload.orderId === 'xyz');
@@ -2319,17 +2293,14 @@ describe('EventStore', function() {
     // -------------------------------------------------------------------------
     describe('tagsAccessor', function() {
 
-        it('creates a tags/ stream lazily on first commit (function form)', function(done) {
-            eventstore = new EventStore({ storageDirectory, tagsAccessor: (e) => e.tags ?? [] });
-            expect(eventstore.getStreamVersion('tags/course:1')).to.be(-1);
-            eventstore.commit('s', [{ tags: ['course:1'] }], () => {
-                expect(eventstore.getStreamVersion('tags/course:1')).to.be(1);
-                done();
-            });
+        it('throws when tagsAccessor is a function', function() {
+            expect(() => new EventStore({ storageDirectory, tagsAccessor: (e) => e.tags ?? [] }))
+                .to.throwError(/tagsAccessor must be a dot-notation string path/);
         });
 
-        it('creates a tags/ stream lazily on first commit (string path form)', function(done) {
+        it('creates a tags/ stream lazily on first commit', function(done) {
             eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            expect(eventstore.getStreamVersion('tags/course:1')).to.be(-1);
             eventstore.commit('s', [{ tags: ['course:1'] }], () => {
                 expect(eventstore.getStreamVersion('tags/course:1')).to.be(1);
                 done();
@@ -2396,7 +2367,7 @@ describe('EventStore', function() {
             });
         });
 
-        describe('fast path (string path form)', function() {
+        describe('fast path', function() {
 
             it('auto-adds payload.<path> to matcherProperties', function() {
                 eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
@@ -2436,6 +2407,97 @@ describe('EventStore', function() {
                 });
             });
 
+        });
+
+    });
+
+    // -------------------------------------------------------------------------
+    // streamSources
+    // -------------------------------------------------------------------------
+    describe('streamSources', function() {
+
+        it('creates a stream lazily on first commit using the nameBuilder', function(done) {
+            eventstore = new EventStore({ storageDirectory, streamSources: [
+                { path: 'category', nameBuilder: (v) => `cat/${v}` }
+            ]});
+            expect(eventstore.getStreamVersion('cat/orders')).to.be(-1);
+            eventstore.commit('s', [{ category: 'orders' }], () => {
+                expect(eventstore.getStreamVersion('cat/orders')).to.be(1);
+                done();
+            });
+        });
+
+        it('handles array property values — one stream per element', function(done) {
+            eventstore = new EventStore({ storageDirectory, streamSources: [
+                { path: 'roles', nameBuilder: (v) => `role/${v}` }
+            ]});
+            eventstore.commit('s', [{ roles: ['admin', 'user'] }], () => {
+                expect(eventstore.getStreamVersion('role/admin')).to.be(1);
+                expect(eventstore.getStreamVersion('role/user')).to.be(1);
+                done();
+            });
+        });
+
+        it('silently skips non-string and empty values', function(done) {
+            eventstore = new EventStore({ storageDirectory, streamSources: [
+                { path: 'x', nameBuilder: (v) => `x/${v}` }
+            ]});
+            eventstore.commit('s', [{ x: 42 }, { x: '' }, { x: null }, {}], () => {
+                const xStreams = Object.keys(eventstore.streams).filter(n => n.startsWith('x/'));
+                expect(xStreams).to.have.length(0);
+                done();
+            });
+        });
+
+        it('multiple sources all apply on the same commit', function(done) {
+            eventstore = new EventStore({ storageDirectory, streamSources: [
+                { path: 'kind', nameBuilder: (v) => `kind/${v}` },
+                { path: 'tenant', nameBuilder: (v) => `tenant/${v}` }
+            ]});
+            eventstore.commit('s', [{ kind: 'order', tenant: 'acme' }], () => {
+                expect(eventstore.getStreamVersion('kind/order')).to.be(1);
+                expect(eventstore.getStreamVersion('tenant/acme')).to.be(1);
+                done();
+            });
+        });
+
+        it('auto-adds payload.path to matcherProperties for each source', function() {
+            eventstore = new EventStore({ storageDirectory, streamSources: [
+                { path: 'category', nameBuilder: (v) => `cat/${v}` }
+            ]});
+            const props = eventstore.storage.indexMatcher.properties;
+            expect(props).to.contain('payload.category');
+        });
+
+        it('stream matcher is classified in the discriminant table (not functionMatchers)', function(done) {
+            eventstore = new EventStore({ storageDirectory, streamSources: [
+                { path: 'category', nameBuilder: (v) => `cat/${v}` }
+            ]});
+            eventstore.commit('s', [{ category: 'orders' }], () => {
+                const im = eventstore.storage.indexMatcher;
+                expect(im.functionMatchers.has('stream-cat/orders')).to.be(false);
+                expect(im.table.get('payload.category')?.has('orders')).to.be(true);
+                done();
+            });
+        });
+
+        it('throws when path is missing', function() {
+            expect(() => new EventStore({ storageDirectory, streamSources: [
+                { nameBuilder: (v) => v }
+            ]})).to.throwError(/non-empty string path/);
+        });
+
+        it('throws when nameBuilder is missing', function() {
+            expect(() => new EventStore({ storageDirectory, streamSources: [
+                { path: 'type' }
+            ]})).to.throwError(/nameBuilder function/);
+        });
+
+        it('throws when nameBuilder produces an invalid stream name', function() {
+            eventstore = new EventStore({ storageDirectory, streamSources: [
+                { path: 'x', nameBuilder: (v) => `bad..${v}` }
+            ]});
+            expect(() => eventstore.commit('s', [{ x: 'foo' }])).to.throwError(/Invalid stream name/);
         });
 
     });

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -2314,6 +2314,181 @@ describe('EventStore', function() {
 
     });
 
+    // -------------------------------------------------------------------------
+    // tagsAccessor
+    // -------------------------------------------------------------------------
+    describe('tagsAccessor', function() {
+
+        it('creates a tags/ stream lazily on first commit (function form)', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: (e) => e.tags ?? [] });
+            expect(eventstore.getStreamVersion('tags/course:1')).to.be(-1);
+            eventstore.commit('s', [{ tags: ['course:1'] }], () => {
+                expect(eventstore.getStreamVersion('tags/course:1')).to.be(1);
+                done();
+            });
+        });
+
+        it('creates a tags/ stream lazily on first commit (string path form)', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [{ tags: ['course:1'] }], () => {
+                expect(eventstore.getStreamVersion('tags/course:1')).to.be(1);
+                done();
+            });
+        });
+
+        it('creates one stream per unique tag value', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [{ tags: ['course:1', 'student:2'] }], () => {
+                expect(eventstore.getStreamVersion('tags/course:1')).to.be(1);
+                expect(eventstore.getStreamVersion('tags/student:2')).to.be(1);
+                done();
+            });
+        });
+
+        it('creates tag streams for all events in a multi-event commit', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [
+                { tags: ['course:1'] },
+                { tags: ['course:2'] }
+            ], () => {
+                expect(eventstore.getStreamVersion('tags/course:1')).to.be(1);
+                expect(eventstore.getStreamVersion('tags/course:2')).to.be(1);
+                done();
+            });
+        });
+
+        it('skips tag stream creation when tags array is empty', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [{ tags: [] }], () => {
+                const tagStreams = Object.keys(eventstore.streams).filter(n => n.startsWith('tags/'));
+                expect(tagStreams).to.have.length(0);
+                done();
+            });
+        });
+
+        it('skips tag stream creation when tags field is absent', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [{ noTags: true }], () => {
+                const tagStreams = Object.keys(eventstore.streams).filter(n => n.startsWith('tags/'));
+                expect(tagStreams).to.have.length(0);
+                done();
+            });
+        });
+
+        it('tag stream contains only events that carry that tag', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [
+                { n: 1, tags: ['course:1'] },
+                { n: 2, tags: ['student:9'] },
+                { n: 3, tags: ['course:1', 'student:9'] }
+            ], () => {
+                const stream = eventstore.getEventStream('tags/course:1');
+                expect(stream.events.map(e => e.n)).to.eql([1, 3]);
+                done();
+            });
+        });
+
+        it('supports hierarchical tag values (slash-separated)', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [{ tags: ['course/jdsj4'] }], () => {
+                expect(eventstore.getStreamVersion('tags/course/jdsj4')).to.be(1);
+                done();
+            });
+        });
+
+    });
+
+    // -------------------------------------------------------------------------
+    // DcbQuery via query()
+    // -------------------------------------------------------------------------
+    describe('DcbQuery via query()', function() {
+
+        it('throws when types referenced but typeAccessor not configured', function() {
+            eventstore = new EventStore({ storageDirectory });
+            expect(() => eventstore.query({ items: [{ types: ['A'] }] }))
+                .to.throwError(/typeAccessor not configured/);
+        });
+
+        it('throws when tags referenced but tagsAccessor not configured', function() {
+            eventstore = new EventStore({ storageDirectory });
+            expect(() => eventstore.query({ items: [{ tags: ['t1'] }] }))
+                .to.throwError(/tagsAccessor not configured/);
+        });
+
+        it('throws when items is empty', function() {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type', tagsAccessor: 'tags' });
+            expect(() => eventstore.query({ items: [] })).to.throwError(/items must be a non-empty array/);
+        });
+
+        it('returns events for a type-only DcbQuery', function(done) {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type' });
+            eventstore.commit('s', [{ type: 'OrderPlaced', n: 1 }, { type: 'OrderShipped', n: 2 }], () => {
+                const { stream } = eventstore.query({ items: [{ types: ['OrderPlaced'] }] });
+                expect(stream.events.map(e => e.n)).to.eql([1]);
+                done();
+            });
+        });
+
+        it('returns events for a tag-only DcbQuery', function(done) {
+            eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+            eventstore.commit('s', [
+                { n: 1, tags: ['course:1'] },
+                { n: 2, tags: ['student:9'] }
+            ], () => {
+                const { stream } = eventstore.query({ items: [{ tags: ['course:1'] }] });
+                expect(stream.events.map(e => e.n)).to.eql([1]);
+                done();
+            });
+        });
+
+        it('returns only events matching both tag AND type', function(done) {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type', tagsAccessor: 'tags' });
+            eventstore.commit('s', [
+                { type: 'CourseCreated',  n: 1, tags: ['course:1'] },
+                { type: 'OrderPlaced',    n: 2, tags: ['course:1'] },
+                { type: 'CourseCreated',  n: 3, tags: ['course:2'] }
+            ], () => {
+                const { stream } = eventstore.query({ items: [{ tags: ['course:1'], types: ['CourseCreated'] }] });
+                expect(stream.events.map(e => e.n)).to.eql([1]);
+                done();
+            });
+        });
+
+        it('returns events across multiple items (OR semantics)', function(done) {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type', tagsAccessor: 'tags' });
+            eventstore.commit('s', [
+                { type: 'CourseCreated', n: 1, tags: ['course:1'] },
+                { type: 'StudentCreated', n: 2, tags: ['student:9'] },
+                { type: 'OrderPlaced',   n: 3, tags: [] }
+            ], () => {
+                const { stream } = eventstore.query({
+                    items: [
+                        { tags: ['course:1'], types: ['CourseCreated'] },
+                        { tags: ['student:9'], types: ['StudentCreated'] }
+                    ]
+                });
+                expect(stream.events.map(e => e.n)).to.eql([1, 2]);
+                done();
+            });
+        });
+
+        it('returns a CommitCondition that detects conflicts', function(done) {
+            eventstore = new EventStore({ storageDirectory, typeAccessor: 'type', tagsAccessor: 'tags' });
+            eventstore.commit('s', [{ type: 'CourseCreated', n: 1, tags: ['course:1'] }], () => {
+                const { condition } = eventstore.query({
+                    items: [{ tags: ['course:1'], types: ['CourseCreated'] }]
+                });
+                // A new conflicting event committed after the query should fail the condition
+                eventstore.commit('s', [{ type: 'CourseCreated', n: 2, tags: ['course:1'] }], () => {
+                    expect(() => eventstore.commit('s', [{ n: 3 }], condition))
+                        .to.throwError(/Optimistic Concurrency/);
+                    done();
+                });
+            });
+        });
+
+    });
+
     describe('makeReadOnly()', function() {
 
         it('switches to read-only mode and calls the callback', function(done) {

--- a/test/EventStore.spec.js
+++ b/test/EventStore.spec.js
@@ -2396,6 +2396,48 @@ describe('EventStore', function() {
             });
         });
 
+        describe('fast path (string path form)', function() {
+
+            it('auto-adds payload.<path> to matcherProperties', function() {
+                eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+                const props = eventstore.storage.indexMatcher.properties;
+                expect(props).to.contain('payload.tags');
+            });
+
+            it('does not duplicate the path when it is already in matcherProperties', function() {
+                eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags',
+                    storageConfig: { matcherProperties: ['stream', 'payload.type', 'payload.tags'] }
+                });
+                const props = eventstore.storage.indexMatcher.properties;
+                const count = props.filter(p => p === 'payload.tags').length;
+                expect(count).to.be(1);
+            });
+
+            it('tag stream matcher is classified in the discriminant table (not functionMatchers)', function(done) {
+                eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+                eventstore.commit('s', [{ tags: ['course:1'] }], () => {
+                    const im = eventstore.storage.indexMatcher;
+                    expect(im.functionMatchers.has('stream-tags/course:1')).to.be(false);
+                    expect(im.table.get('payload.tags')?.has('course:1')).to.be(true);
+                    done();
+                });
+            });
+
+            it('tag stream still indexes the correct events via the fast path', function(done) {
+                eventstore = new EventStore({ storageDirectory, tagsAccessor: 'tags' });
+                eventstore.commit('s', [
+                    { n: 1, tags: ['course:1'] },
+                    { n: 2, tags: ['student:9'] },
+                    { n: 3, tags: ['course:1', 'student:9'] }
+                ], () => {
+                    expect(eventstore.getEventStream('tags/course:1').events.map(e => e.n)).to.eql([1, 3]);
+                    expect(eventstore.getEventStream('tags/student:9').events.map(e => e.n)).to.eql([2, 3]);
+                    done();
+                });
+            });
+
+        });
+
     });
 
     // -------------------------------------------------------------------------

--- a/test/IndexMatcher.spec.js
+++ b/test/IndexMatcher.spec.js
@@ -53,6 +53,39 @@ describe('IndexMatcher', function() {
 
     });
 
+    describe('findDiscriminant $has handling', function() {
+
+        it('does not treat a matcher with a non-$has operator as a $has discriminant', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            // Non-$has operator falls through: no discriminant, stays unclassified.
+            im.add('tag-ne', { payload: { tags: { $ne: 'x' } } });
+            expect(im.unclassifiedMatchers.has('tag-ne')).to.be(true);
+        });
+
+        it('does not treat an object with multiple keys as a $has discriminant', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            im.add('tag-mixed', { payload: { tags: { $has: 'x', $ne: 'y' } } });
+            expect(im.unclassifiedMatchers.has('tag-mixed')).to.be(true);
+        });
+
+        it('does not treat an empty array discriminant value as a $has scalar', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            // Empty array: not a valid array discriminant (length 0) and Array.isArray is
+            // guarded inside isLoneHasScalar, so this falls through to unclassified.
+            im.add('tag-empty', { payload: { tags: [] } });
+            expect(im.unclassifiedMatchers.has('tag-empty')).to.be(true);
+        });
+
+        it('does not treat an array with non-scalar elements as a $has scalar', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            // Array containing an object: fails the "all scalars" branch, then falls into
+            // isLoneHasScalar which rejects arrays outright.
+            im.add('tag-mixed-arr', { payload: { tags: [{ nested: true }] } });
+            expect(im.unclassifiedMatchers.has('tag-mixed-arr')).to.be(true);
+        });
+
+    });
+
     describe('remove', function() {
 
         it('is a no-op for unknown index names', function() {

--- a/test/IndexMatcher.spec.js
+++ b/test/IndexMatcher.spec.js
@@ -3,6 +3,56 @@ import IndexMatcher from '../src/IndexMatcher.js';
 
 describe('IndexMatcher', function() {
 
+    describe('forEachMatch with array document properties', function() {
+
+        it('matches an index when document array contains the discriminant value', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+
+            const hits = [];
+            im.forEachMatch({ payload: { tags: ['course:1', 'student:9'] } }, n => hits.push(n));
+            expect(hits).to.eql(['stream-tags/course:1']);
+        });
+
+        it('does not match when the discriminant value is absent from the array', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+
+            const hits = [];
+            im.forEachMatch({ payload: { tags: ['student:9'] } }, n => hits.push(n));
+            expect(hits).to.eql([]);
+        });
+
+        it('resolves multiple indexes from multiple array elements', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+            im.add('stream-tags/student:9', { payload: { tags: 'student:9' } });
+
+            const hits = [];
+            im.forEachMatch({ payload: { tags: ['course:1', 'student:9'] } }, n => hits.push(n));
+            expect(hits.sort()).to.eql(['stream-tags/course:1', 'stream-tags/student:9']);
+        });
+
+        it('deduplicates when duplicate array elements map to the same index', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+
+            const hits = [];
+            im.forEachMatch({ payload: { tags: ['course:1', 'course:1'] } }, n => hits.push(n));
+            expect(hits).to.eql(['stream-tags/course:1']);
+        });
+
+        it('ignores non-scalar array elements (objects, nulls)', function() {
+            const im = new IndexMatcher(['payload.tags']);
+            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+
+            const hits = [];
+            im.forEachMatch({ payload: { tags: [null, {nested: true}, 'course:1'] } }, n => hits.push(n));
+            expect(hits).to.eql(['stream-tags/course:1']);
+        });
+
+    });
+
     describe('remove', function() {
 
         it('is a no-op for unknown index names', function() {

--- a/test/IndexMatcher.spec.js
+++ b/test/IndexMatcher.spec.js
@@ -7,7 +7,7 @@ describe('IndexMatcher', function() {
 
         it('matches an index when document array contains the discriminant value', function() {
             const im = new IndexMatcher(['payload.tags']);
-            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+            im.add('stream-tags/course:1', { payload: { tags: { $has: 'course:1' } } });
 
             const hits = [];
             im.forEachMatch({ payload: { tags: ['course:1', 'student:9'] } }, n => hits.push(n));
@@ -16,7 +16,7 @@ describe('IndexMatcher', function() {
 
         it('does not match when the discriminant value is absent from the array', function() {
             const im = new IndexMatcher(['payload.tags']);
-            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+            im.add('stream-tags/course:1', { payload: { tags: { $has: 'course:1' } } });
 
             const hits = [];
             im.forEachMatch({ payload: { tags: ['student:9'] } }, n => hits.push(n));
@@ -25,8 +25,8 @@ describe('IndexMatcher', function() {
 
         it('resolves multiple indexes from multiple array elements', function() {
             const im = new IndexMatcher(['payload.tags']);
-            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
-            im.add('stream-tags/student:9', { payload: { tags: 'student:9' } });
+            im.add('stream-tags/course:1', { payload: { tags: { $has: 'course:1' } } });
+            im.add('stream-tags/student:9', { payload: { tags: { $has: 'student:9' } } });
 
             const hits = [];
             im.forEachMatch({ payload: { tags: ['course:1', 'student:9'] } }, n => hits.push(n));
@@ -35,7 +35,7 @@ describe('IndexMatcher', function() {
 
         it('deduplicates when duplicate array elements map to the same index', function() {
             const im = new IndexMatcher(['payload.tags']);
-            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+            im.add('stream-tags/course:1', { payload: { tags: { $has: 'course:1' } } });
 
             const hits = [];
             im.forEachMatch({ payload: { tags: ['course:1', 'course:1'] } }, n => hits.push(n));
@@ -44,7 +44,7 @@ describe('IndexMatcher', function() {
 
         it('ignores non-scalar array elements (objects, nulls)', function() {
             const im = new IndexMatcher(['payload.tags']);
-            im.add('stream-tags/course:1', { payload: { tags: 'course:1' } });
+            im.add('stream-tags/course:1', { payload: { tags: { $has: 'course:1' } } });
 
             const hits = [];
             im.forEachMatch({ payload: { tags: [null, {nested: true}, 'course:1'] } }, n => hits.push(n));

--- a/test/dcbUtil.spec.js
+++ b/test/dcbUtil.spec.js
@@ -1,0 +1,194 @@
+import expect from 'expect.js';
+import {compileDcbQuery, isDcbQuery} from '../src/utils/dcbUtil.js';
+
+const resolveType = (type) => type;
+const resolveTag = (tag) => 'tags/' + tag;
+const throwOnType = () => {
+    throw new Error('typeAccessor not configured');
+};
+const throwOnTag = () => {
+    throw new Error('tagsAccessor not configured');
+};
+
+describe('dcbUtil', function () {
+
+    describe('isDcbQuery', function () {
+
+        it('returns true for a plain object with items property', function () {
+            expect(isDcbQuery({items: []})).to.be(true);
+            expect(isDcbQuery({items: [{types: ['A']}]})).to.be(true);
+        });
+
+        it('returns false for arrays', function () {
+            expect(isDcbQuery(['A', 'B'])).to.be(false);
+            expect(isDcbQuery([])).to.be(false);
+        });
+
+        it('returns false for null and primitives', function () {
+            expect(isDcbQuery(null)).to.be(false);
+            expect(isDcbQuery(undefined)).to.be(false);
+            expect(isDcbQuery('string')).to.be(false);
+            expect(isDcbQuery(42)).to.be(false);
+        });
+
+        it('returns false for objects without an items property', function () {
+            expect(isDcbQuery({types: ['A']})).to.be(false);
+            expect(isDcbQuery({})).to.be(false);
+        });
+
+    });
+
+    describe('compileDcbQuery', function () {
+
+        describe('query-level validation', function () {
+
+            it('throws when items is missing', function () {
+                expect(() => compileDcbQuery({}, resolveType, resolveTag)).to.throwError(/items must be a non-empty array/);
+            });
+
+            it('throws when items is null', function () {
+                expect(() => compileDcbQuery({items: null}, resolveType, resolveTag)).to.throwError(/items must be a non-empty array/);
+            });
+
+            it('throws when items is an empty array', function () {
+                expect(() => compileDcbQuery({items: []}, resolveType, resolveTag)).to.throwError(/items must be a non-empty array/);
+            });
+
+        });
+
+        describe('item-level validation', function () {
+
+            it('throws when an item is null', function () {
+                expect(() => compileDcbQuery({items: [null]}, resolveType, resolveTag)).to.throwError(/item must be an object/);
+            });
+
+            it('throws when an item is undefined', function () {
+                expect(() => compileDcbQuery({items: [undefined]}, resolveType, resolveTag)).to.throwError(/item must be an object/);
+            });
+
+            it('throws when item.types is null', function () {
+                expect(() => compileDcbQuery({items: [{types: null}]}, resolveType, resolveTag)).to.throwError(/item\.types must be an array/);
+            });
+
+            it('throws when item.tags is null', function () {
+                expect(() => compileDcbQuery({items: [{tags: null}]}, resolveType, resolveTag)).to.throwError(/item\.tags must be an array/);
+            });
+
+            it('throws when item.types is a non-array value', function () {
+                expect(() => compileDcbQuery({items: [{types: 'A'}]}, resolveType, resolveTag)).to.throwError(/item\.types must be an array/);
+            });
+
+        });
+
+        describe('unconstrained items', function () {
+
+            it('compiles {} to _all', function () {
+                expect(compileDcbQuery({items: [{}]}, resolveType, resolveTag)).to.eql(['_all']);
+            });
+
+            it('compiles {types: []} to _all', function () {
+                expect(compileDcbQuery({items: [{types: []}]}, resolveType, resolveTag)).to.eql(['_all']);
+            });
+
+            it('compiles {tags: []} to _all', function () {
+                expect(compileDcbQuery({items: [{tags: []}]}, resolveType, resolveTag)).to.eql(['_all']);
+            });
+
+            it('compiles {types: [], tags: []} to _all', function () {
+                expect(compileDcbQuery({items: [{types: [], tags: []}]}, resolveType, resolveTag)).to.eql(['_all']);
+            });
+
+        });
+
+        describe('type-only items', function () {
+
+            it('compiles a single type to a plain string', function () {
+                expect(compileDcbQuery({items: [{types: ['A']}]}, resolveType, resolveTag)).to.eql(['A']);
+            });
+
+            it('compiles multiple types to a flat array (OR group)', function () {
+                expect(compileDcbQuery({items: [{types: ['A', 'B']}]}, resolveType, resolveTag)).to.eql([['A', 'B']]);
+            });
+
+        });
+
+        describe('tag-only items', function () {
+
+            it('compiles a single tag to a tags/ prefixed string', function () {
+                expect(compileDcbQuery({items: [{tags: ['t1']}]}, resolveType, resolveTag)).to.eql(['tags/t1']);
+            });
+
+            it('compiles multiple tags to an AND array with tags/ prefix', function () {
+                expect(compileDcbQuery({items: [{tags: ['t1', 't2']}]}, resolveType, resolveTag)).to.eql([['tags/t1', 'tags/t2']]);
+            });
+
+        });
+
+        describe('combined tag + type items', function () {
+
+            it('compiles tag + single type to an AND array', function () {
+                const result = compileDcbQuery({
+                    items: [{
+                        tags: ['course:1'],
+                        types: ['OrderPlaced']
+                    }]
+                }, resolveType, resolveTag);
+                expect(result).to.eql([['tags/course:1', 'OrderPlaced']]);
+            });
+
+            it('compiles tag + multiple types to AND array with nested OR group', function () {
+                const result = compileDcbQuery({
+                    items: [{
+                        tags: ['course:1'],
+                        types: ['A', 'B']
+                    }]
+                }, resolveType, resolveTag);
+                expect(result).to.eql([['tags/course:1', ['A', 'B']]]);
+            });
+
+            it('compiles multiple tags + multiple types correctly', function () {
+                const result = compileDcbQuery({
+                    items: [{
+                        tags: ['t1', 't2'],
+                        types: ['A', 'B']
+                    }]
+                }, resolveType, resolveTag);
+                expect(result).to.eql([['tags/t1', 'tags/t2', ['A', 'B']]]);
+            });
+
+        });
+
+        describe('multi-item queries', function () {
+
+            it('wraps multiple items in a top-level OR array', function () {
+                const result = compileDcbQuery({
+                    items: [
+                        {tags: ['course:1'], types: ['CourseCreated', 'CourseCapacityChanged']},
+                        {tags: ['student:2'], types: ['StudentCreated']}
+                    ]
+                }, resolveType, resolveTag);
+                expect(result).to.eql([
+                    ['tags/course:1', ['CourseCreated', 'CourseCapacityChanged']],
+                    ['tags/student:2', 'StudentCreated']
+                ]);
+            });
+
+        });
+
+        describe('resolver delegation', function () {
+
+            it('propagates errors from resolveType', function () {
+                expect(() => compileDcbQuery({items: [{types: ['A']}]}, throwOnType, resolveTag))
+                    .to.throwError(/typeAccessor not configured/);
+            });
+
+            it('propagates errors from resolveTag', function () {
+                expect(() => compileDcbQuery({items: [{tags: ['t1']}]}, resolveType, throwOnTag))
+                    .to.throwError(/tagsAccessor not configured/);
+            });
+
+        });
+
+    });
+
+});

--- a/test/dcbUtil.spec.js
+++ b/test/dcbUtil.spec.js
@@ -106,8 +106,8 @@ describe('dcbUtil', function () {
                 expect(compileDcbQuery({items: [{types: ['A']}]}, resolveType, resolveTag)).to.eql(['A']);
             });
 
-            it('compiles multiple types to a flat array (OR group)', function () {
-                expect(compileDcbQuery({items: [{types: ['A', 'B']}]}, resolveType, resolveTag)).to.eql([['A', 'B']]);
+            it('compiles multiple types to a nested OR group', function () {
+                expect(compileDcbQuery({items: [{types: ['A', 'B']}]}, resolveType, resolveTag)).to.eql([[['A', 'B']]]);
             });
 
         });

--- a/test/metadataUtil.spec.js
+++ b/test/metadataUtil.spec.js
@@ -349,6 +349,32 @@ describe('metadataUtil', function () {
             expect(matcher(Buffer.from('{"amount":150,"type":"Foo"}', 'utf8'))).to.be(false);
         });
 
+        it('matches with lone $has for tag arrays', function () {
+            const matcher = buildRawBufferMatcher({tags: {$has: 'featured'}});
+            expect(matcher(Buffer.from('{"tags":["featured","new"]}', 'utf8'))).to.be(true);
+            expect(matcher(Buffer.from('{"tags":["new","featured"]}', 'utf8'))).to.be(true);
+            expect(matcher(Buffer.from('{"tags":["archived"]}', 'utf8'))).to.be(false);
+            expect(matcher(Buffer.from('{"tags":[]}', 'utf8'))).to.be(false);
+            expect(matcher(Buffer.from('{"other":["featured"]}', 'utf8'))).to.be(false);
+        });
+
+        it('$has ignores matches inside nested objects/arrays at wrong depth', function () {
+            const matcher = buildRawBufferMatcher({tags: {$has: 'x'}});
+            // "x" appears only inside a nested object, not as an element of tags itself
+            expect(matcher(Buffer.from('{"tags":[{"inner":"x"}]}', 'utf8'))).to.be(false);
+            // "x" appears inside a nested array element, not as an element of tags itself
+            expect(matcher(Buffer.from('{"tags":[["x"]]}', 'utf8'))).to.be(false);
+            // "x" appears as an actual element
+            expect(matcher(Buffer.from('{"tags":[{"inner":"y"},"x"]}', 'utf8'))).to.be(true);
+        });
+
+        it('$has combines with other property matchers', function () {
+            const matcher = buildRawBufferMatcher({type: 'OrderPlaced', tags: {$has: 'vip'}});
+            expect(matcher(Buffer.from('{"type":"OrderPlaced","tags":["vip"]}', 'utf8'))).to.be(true);
+            expect(matcher(Buffer.from('{"type":"OrderPlaced","tags":["regular"]}', 'utf8'))).to.be(false);
+            expect(matcher(Buffer.from('{"type":"OrderCancelled","tags":["vip"]}', 'utf8'))).to.be(false);
+        });
+
     });
 
     describe('matches with operators ($gt, $gte, $lt, $lte, $eq, $ne)', function () {
@@ -443,11 +469,22 @@ describe('metadataUtil', function () {
             expect(matches({status: 'completed'}, {status: ['active', 'pending']})).to.be(false);
         });
 
-        it('handles array document value with scalar matcher (containment check)', function () {
-            expect(matches({tags: ['a', 'b']}, {tags: 'a'})).to.be(true);
-            expect(matches({tags: ['a', 'b']}, {tags: 'b'})).to.be(true);
-            expect(matches({tags: ['a', 'b']}, {tags: 'c'})).to.be(false);
-            expect(matches({tags: []}, {tags: 'a'})).to.be(false);
+        it('handles array document value with $has operator (containment check)', function () {
+            expect(matches({tags: ['a', 'b']}, {tags: {$has: 'a'}})).to.be(true);
+            expect(matches({tags: ['a', 'b']}, {tags: {$has: 'b'}})).to.be(true);
+            expect(matches({tags: ['a', 'b']}, {tags: {$has: 'c'}})).to.be(false);
+            expect(matches({tags: []}, {tags: {$has: 'a'}})).to.be(false);
+            expect(matches({}, {tags: {$has: 'a'}})).to.be(false);
+        });
+
+        it('$has returns false when the document value is not an array', function () {
+            expect(matches({tags: 'a'}, {tags: {$has: 'a'}})).to.be(false);
+            expect(matches({tags: {a: 1}}, {tags: {$has: 'a'}})).to.be(false);
+        });
+
+        it('scalar matcher against array document value no longer performs containment', function () {
+            // Historical auto-containment removed in favor of the explicit $has operator.
+            expect(matches({tags: ['a', 'b']}, {tags: 'a'})).to.be(false);
         });
 
         it('handles nested object matching without operators', function () {

--- a/test/metadataUtil.spec.js
+++ b/test/metadataUtil.spec.js
@@ -4,7 +4,7 @@ import {
     buildRawBufferMatcher,
     buildMetadataForMatcher,
     buildMatcherFromMetadata,
-    buildTypeMatcherFn,
+    buildMatcherFn,
     buildMetadataHeader,
     createHmac
 } from '../src/utils/metadataUtil.js';
@@ -523,20 +523,30 @@ describe('metadataUtil', function () {
         });
 
         it('builds type matcher functions for single-level paths', function () {
-            const typeMatcher = buildTypeMatcherFn('type');
+            const typeMatcher = buildMatcherFn('type');
             expect(typeMatcher('OrderPlaced')).to.eql({payload: {type: 'OrderPlaced'}});
         });
 
         it('builds type matcher functions for nested paths', function () {
-            const typeMatcher = buildTypeMatcherFn('meta.kind');
+            const typeMatcher = buildMatcherFn('meta.kind');
             expect(typeMatcher('OrderPlaced')).to.eql({payload: {meta: {kind: 'OrderPlaced'}}});
         });
 
         it('builds type matcher functions for deeply nested paths', function () {
-            const typeMatcher = buildTypeMatcherFn('deeply.nested.type');
+            const typeMatcher = buildMatcherFn('deeply.nested.type');
             expect(typeMatcher('MyEvent')).to.eql({
                 payload: {deeply: {nested: {type: 'MyEvent'}}}
             });
+        });
+
+        it('folds a $eq operator into a scalar matcher', function () {
+            const scalar = buildMatcherFn('type', '$eq');
+            expect(scalar('OrderPlaced')).to.eql({payload: {type: 'OrderPlaced'}});
+        });
+
+        it('wraps the leaf in the given operator for non-scalar operators', function () {
+            const tagMatcher = buildMatcherFn('tags', '$has');
+            expect(tagMatcher('featured')).to.eql({payload: {tags: {$has: 'featured'}}});
         });
 
         it('builds a padded metadata header', function () {

--- a/test/metadataUtil.spec.js
+++ b/test/metadataUtil.spec.js
@@ -443,6 +443,13 @@ describe('metadataUtil', function () {
             expect(matches({status: 'completed'}, {status: ['active', 'pending']})).to.be(false);
         });
 
+        it('handles array document value with scalar matcher (containment check)', function () {
+            expect(matches({tags: ['a', 'b']}, {tags: 'a'})).to.be(true);
+            expect(matches({tags: ['a', 'b']}, {tags: 'b'})).to.be(true);
+            expect(matches({tags: ['a', 'b']}, {tags: 'c'})).to.be(false);
+            expect(matches({tags: []}, {tags: 'a'})).to.be(false);
+        });
+
         it('handles nested object matching without operators', function () {
             expect(matches({meta: {kind: 'A', version: 1}}, {meta: {kind: 'A'}})).to.be(true);
             expect(matches({meta: {kind: 'B'}}, {meta: {kind: 'A'}})).to.be(false);

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect.js';
 import fs from 'fs-extra';
 import path from 'path';
-import { iterate } from '../src/utils/util.js';
+import { iterate, compileAccessor } from '../src/utils/util.js';
 import { scanForFiles } from '../src/utils/fsUtil.js';
 import { fileURLToPath } from 'url';
 
@@ -88,6 +88,35 @@ describe('util', function() {
                 expect(err).to.be.an(Error);
                 done();
             });
+        });
+
+    });
+
+    describe('compileAccessor', function() {
+
+        it('returns a direct-property accessor for a single-part path', function() {
+            const acc = compileAccessor('type');
+            expect(acc({ type: 'OrderPlaced' })).to.be('OrderPlaced');
+            expect(acc({})).to.be(undefined);
+        });
+
+        it('returns undefined when the object is null or undefined (single-part path)', function() {
+            const acc = compileAccessor('type');
+            expect(acc(null)).to.be(undefined);
+            expect(acc(undefined)).to.be(undefined);
+        });
+
+        it('resolves nested dot-notation paths', function() {
+            const acc = compileAccessor('payload.user.id');
+            expect(acc({ payload: { user: { id: 42 } } })).to.be(42);
+        });
+
+        it('returns undefined for missing nested segments', function() {
+            const acc = compileAccessor('payload.user.id');
+            expect(acc(null)).to.be(undefined);
+            expect(acc({})).to.be(undefined);
+            expect(acc({ payload: null })).to.be(undefined);
+            expect(acc({ payload: { user: 'not-an-object' } })).to.be(undefined);
         });
 
     });


### PR DESCRIPTION
This pull request introduces several major improvements to EventStore's querying capabilities, focusing on DCB (Dynamic Consistency Boundary) support, dynamic stream indexing, and enhanced documentation. The most important changes include a new generic `streamSources` mechanism for automatic stream indexing, the addition of `tagsAccessor` for tag-based streams, a new DCB query shorthand syntax, and comprehensive updates to the documentation explaining these features and their trade-offs.

**Dynamic Stream Indexing and Query Enhancements**
- Added the `streamSources` configuration option, allowing users to define custom stream indexes for any payload property. This enables automatic maintenance of dedicated streams for properties like tenant IDs, types, or tags, with O(1) index routing. (`src/EventStore.js` [[1]](diffhunk://#diff-0f0c40de44a0841ed5180f16d66212d1cece2a7d4400789007c2f73bf8432622R63-R95) [[2]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L75-R100)
- Introduced the `tagsAccessor` option as a shorthand for creating tag-based streams from an array property in the payload. This supports efficient tag queries and is integrated with DCB query resolution. (`src/EventStore.js` [[1]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L75-R100) [[2]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R7-R13)
- Implemented DCB query shorthand syntax: `store.query({ items: [{ types, tags }] })` can now be used instead of manually constructing the nested selector algebra. This requires `typeAccessor` and/or `tagsAccessor` to be configured. (`src/EventStore.js` [[1]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0R34-R44) [[2]](diffhunk://#diff-9f416bc37ef3d86c4e728695956bdf9e5af4e1cf08d5432802cfbd43330e88c0L9-R14) [[3]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R7-R13)

**Documentation Updates**
- Expanded and clarified the DCB documentation to explain the new query model, the role of `typeAccessor` and `tagsAccessor`, and the difference between matcher-only and tag-stream queries. Includes practical examples, trade-off discussions, and advanced selector algebra details. (`docs/dcb.md` [[1]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L23-R123) [[2]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L89-L118) [[3]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L157-R185) [[4]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637R198-R201) [[5]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L226-R212) [[6]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637L251-R236) [[7]](diffhunk://#diff-c256dc62acead27ad8ae6ecc8b88c117b21efed3676072c54e6b3d3e04540637R251-R273)
- Added a section to the advanced documentation describing dynamic stream indexing and how to use the new `streamSources`, `typeAccessor`, and `tagsAccessor` options. (`docs/advanced.md` [docs/advanced.mdR63-R95](diffhunk://#diff-0f0c40de44a0841ed5180f16d66212d1cece2a7d4400789007c2f73bf8432622R63-R95))
- Updated the changelog to reflect all new features, including the DCB query shorthand, `tagsAccessor`, and `streamSources`. Also noted a minor bugfix in `JoinStream`. (`docs/changelog.md` [docs/changelog.mdR7-R13](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R7-R13))

These changes make it much easier to configure and use DCB-style queries, improve performance for high-cardinality or high-throughput use cases, and provide clear guidance on when to use matcher-only versus stream-indexed queries.